### PR TITLE
CIS 1.19

### DIFF
--- a/cis_enforcements/aws/cis_v300_s1_iam/server_certificates.tf
+++ b/cis_enforcements/aws/cis_v300_s1_iam/server_certificates.tf
@@ -1,0 +1,16 @@
+# AWS > IAM > Server Certificate > Active
+resource "turbot_policy_setting" "aws_iam_server_certificate_active" {
+  resource = turbot_smart_folder.aws_cis_v300_s1_iam.id
+  type     = "tmod:@turbot/aws-iam#/policy/types/serverCertificateActive"
+  note     = "AWS CIS v3.0.0 - Controls: 1.19"
+  value    = "Check: Active"
+  # value    = "Enforce: Delete inactive with 1 day warning"
+}
+
+# AWS > IAM > Server Certificate > Active > Expired
+resource "turbot_policy_setting" "aws_iam_server_certificate_active_expired" {
+  resource = turbot_smart_folder.aws_cis_v300_s1_iam.id
+  type     = "tmod:@turbot/aws-iam#/policy/types/serverCertificateActiveExpired"
+  note     = "AWS CIS v3.0.0 - Controls: 1.19"
+  value    = "Force inactive if expired"
+}


### PR DESCRIPTION
CIS 1.19
- Use AWS > IAM > Server Certificate > Active and # AWS > IAM > Server Certificate > Active > Expired to clean up expired Server Certificates.
- Depends on [aws-iam 5.36.0](https://turbot.com/guardrails/changelog/aws-iam-v5-36-0).