### PR TITLE
Add GCP Compute Engine Policy pack

### DIFF
--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/README.md
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["compute", "security"]
+primary_category: "security"
+---
+# Enforce GCP Compute Engine Instances to not use Unapproved Images
+
+Enforcing GCP Compute Engine instances to not use unapproved images is crucial for maintaining security, compliance, and consistency across the infrastructure. It ensures that all instances adhere to organizational standards, reducing the risk of vulnerabilities, unauthorized software, and potential breaches.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/smart-folders) can help you configure the following settings for Compute Engine instances:
+
+- Set list of approved image IDs
+- Stop/Terminate instances that use unapproved images
+
+**[Review policy settings →](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/policy-packs/enforce_instances_to_not_use_unapproved_images/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli)
+- Guardrails mods:
+  - [@turbot/gcp-computeengine](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/gcp/mods/gcp-computeengine)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/working-with-folders/smart#attach-a-smart-folder-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/smart-folders).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "gcp_computeengine_instance_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-computeengine#/policy/types/instanceApproved"
+  # value    = "Check: Approved"
+  value    = "Enforce: Stop unapproved"
+  # value    = "Enforce: Delete unapproved if new"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/README.md
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/README.md
@@ -2,7 +2,7 @@
 categories: ["compute", "security"]
 primary_category: "security"
 ---
-# Enforce GCP Compute Engine Instances to not use Unapproved Images
+# Enforce GCP Compute Engine Instances To Not Use Unapproved Images
 
 Enforcing GCP Compute Engine instances to not use unapproved images is crucial for maintaining security, compliance, and consistency across the infrastructure. It ensures that all instances adhere to organizational standards, reducing the risk of vulnerabilities, unauthorized software, and potential breaches.
 

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/main.tf
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce GCP Compute Engine Instances to not use Unapproved Images"
+  description = "Ensure that all instances adhere to organizational standards, reducing the risk of vulnerabilities."
+  akas        = ["gcp_computeengine_enforce_instances_to_not_use_unapproved_images"]
+}

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/main.tf
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/main.tf
@@ -1,5 +1,5 @@
 resource "turbot_policy_pack" "main" {
-  title       = "Enforce GCP Compute Engine Instances to not use Unapproved Images"
+  title       = "Enforce GCP Compute Engine Instances To Not Use Unapproved Images"
   description = "Ensure that all instances adhere to organizational standards, reducing the risk of vulnerabilities."
   akas        = ["gcp_computeengine_enforce_instances_to_not_use_unapproved_images"]
 }

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/policies.tf
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/policies.tf
@@ -41,7 +41,7 @@ resource "turbot_policy_setting" "gcp_computeengine_instance_approved_custom" {
     {%- set data = {
         "title": "Image"
         "result": "Approved"
-        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is approved for usage
+        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is approved for use
     } -%}
 
   {%- elif $.disks.items | length > 0 and $.disks.items[0].sourceImageId not in $.approvedImageIds -%}
@@ -49,7 +49,7 @@ resource "turbot_policy_setting" "gcp_computeengine_instance_approved_custom" {
     {%- set data = {
         "title": "Image"
         "result": "Not approved"
-        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is not approved for usage
+        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is not approved for use
     } -%}
   
   {%- else -%}

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/policies.tf
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/policies.tf
@@ -25,7 +25,7 @@ resource "turbot_policy_setting" "gcp_computeengine_instance_approved_custom" {
     }
   - |
     {
-      disks: resources(filter: "resourceTypeId:'tmod:@turbot/gcp-computeengine#/resource/types/disk' $.name:{{ $.resource.rootDiskName }} resourceId:{{ $.project.turbot.id }} resourceTypeLevel:self") {
+      disks: resources(filter: "resourceTypeId:'tmod:@turbot/gcp-computeengine#/resource/types/disk' $.name:'{{ $.resource.rootDiskName }}' resourceId:{{ $.project.turbot.id }} resourceTypeLevel:self") {
         items {
           sourceImage: get(path: "sourceImage")
           sourceImageId: get(path: "sourceImageId")
@@ -39,17 +39,17 @@ resource "turbot_policy_setting" "gcp_computeengine_instance_approved_custom" {
   {%- if $.disks.items | length > 0 and $.disks.items[0].sourceImageId in $.approvedImageIds -%}
 
     {%- set data = {
-        "title": "Image"
-        "result": "Approved"
-        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is approved for use
+        "title": "Image",
+        "result": "Approved",
+        "message": "Image is approved for use"
     } -%}
 
   {%- elif $.disks.items | length > 0 and $.disks.items[0].sourceImageId not in $.approvedImageIds -%}
 
     {%- set data = {
-        "title": "Image"
-        "result": "Not approved"
-        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is not approved for use
+        "title": "Image",
+        "result": "Not approved",
+        "message": "Image is not approved for use"
     } -%}
   
   {%- else -%}

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/policies.tf
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/policies.tf
@@ -1,0 +1,67 @@
+# GCP > Compute Engine > Instance > Approved
+resource "turbot_policy_setting" "gcp_computeengine_instance_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-computeengine#/policy/types/instanceApproved"
+  value    = "Check: Approved"
+  # value    = "Enforce: Stop unapproved"
+  # value    = "Enforce: Delete unapproved if new"
+}
+
+# GCP > Compute Engine > Instance > Approved > Custom
+resource "turbot_policy_setting" "gcp_computeengine_instance_approved_custom" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/gcp-computeengine#/policy/types/instanceApprovedCustom"
+  template_input = <<-EOT
+  - |
+    {
+      project {
+        turbot {
+          id
+        }
+      }
+      resource {
+        rootDiskName: get(path: "disks[0].deviceName")
+      }
+    }
+  - |
+    {
+      disks: resources(filter: "resourceTypeId:'tmod:@turbot/gcp-computeengine#/resource/types/disk' $.name:{{ $.resource.rootDiskName }} resourceId:{{ $.project.turbot.id }} resourceTypeLevel:self") {
+        items {
+          sourceImage: get(path: "sourceImage")
+          sourceImageId: get(path: "sourceImageId")
+        }
+      }
+      # Your list of approved image IDs
+      approvedImageIds: constant(value: "['4644004327634874935', '4801817364715522935']")
+    }
+  EOT
+  template       = <<-EOT
+  {%- if $.disks.items | length > 0 and $.disks.items[0].sourceImageId in $.approvedImageIds -%}
+
+    {%- set data = {
+        "title": "Image"
+        "result": "Approved"
+        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is approved for usage
+    } -%}
+
+  {%- elif $.disks.items | length > 0 and $.disks.items[0].sourceImageId not in $.approvedImageIds -%}
+
+    {%- set data = {
+        "title": "Image"
+        "result": "Not approved"
+        "message": Image {{ $.disks.items[0].sourceImage.split('/').pop() }} is not approved for usage
+    } -%}
+  
+  {%- else -%}
+
+    {%- set data = {
+        "title": "Image",
+        "result": "Skip",
+        "message": "No data for image yet"
+    } -%}
+
+  {%- endif -%}
+
+  {{ data | json }}
+  EOT
+}

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/providers.tf
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    turbot = {
+      source = "turbot/turbot"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
### Added
- [ ] GCP > Compute Engine > Instance  - [Enforce GCP Compute Engine Instances to not use Unapproved Images](https://parker-turbot.cloud.turbot-dev.com/apollo/resources/327005152423590/detail)

### Screenshots
![image](https://github.com/user-attachments/assets/025ca3b2-c6ee-4e9e-9cfb-42f9005683d5)
![Uploading image.png…]()
