### PR TITLE
Add AWS VPC Policy Packs 3

### DIFF
--- a/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["networking", "security"]
+primary_category: "security"
+---
+
+# Enforce Default VPCs To Not Exist
+
+Enforcing that Default VPCs do not exist is crucial for maintaining network security and control, as default VPCs often come with pre-configured settings that might not align with an organization's specific security and compliance requirements. By removing Default VPCs, administrators can ensure that all VPCs are created with custom configurations tailored to their security policies and operational needs, reducing the risk of unintended exposure or misconfiguration.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/smart-folders) can help you configure the following settings for Default VPCs:
+
+- Delete Default VPCs if available
+
+## Documentation
+
+- **[Review Policy settings →](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/policy-packs/enforce_default_vpcs_to_not_exist/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+- Guardrails mods:
+  - [@turbot/aws-vpc-core](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/aws/mods/aws-vpc-core)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/working-with-folders/smart#attach-a-smart-folder-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/smart-folders).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_vpc_default_vpc_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-core#/policy/types/defaultVpcApproved"
+  # value    = "Check: Approved"
+  value    = "Enforce: Force delete unapproved"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/main.tf
+++ b/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Default VPCs To Not Exist"
+  description = "This measure ensure that all VPCs are created with custom configurations tailored to their security policies and operational needs, reducing the risk of unintended exposure or misconfiguration."
+  akas        = ["aws_vpc_enforce_default_vpcs_to_not_exist"]
+}

--- a/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/policies.tf
+++ b/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/policies.tf
@@ -1,0 +1,14 @@
+# AWS > VPC > Default VPC > Approved
+resource "turbot_policy_setting" "aws_vpc_default_vpc_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-core#/policy/types/defaultVpcApproved"
+  value    = "Check: Approved"
+  # value    = "Enforce: Force delete unapproved"
+}
+
+# AWS > VPC > Default VPC > Approved > Usage
+resource "turbot_policy_setting" "aws_vpc_default_vpc_approved_usage" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-core#/policy/types/defaultVpcApprovedUsage"
+  value    = "Not approved"
+}

--- a/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/providers.tf
+++ b/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    turbot = {
+      source = "turbot/turbot"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["networking", "security"]
+primary_category: "security"
+---
+
+# Enforce Elastic IPs To Not Exist
+
+Enforcing the non-existence of Elastic IPs is crucial to enhance security and cost management within a cloud environment. By preventing the allocation of Elastic IPs, organizations can reduce the risk of public exposure of their resources and minimize potential attack surfaces, while also controlling unnecessary expenses associated with idle IP addresses.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/smart-folders) can help you configure the following settings for VPC elastic ips:
+
+- Delete Elastic IPs if available
+
+## Documentation
+
+- **[Review Policy settings →](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/policy-packs/enforce_elastic_ips_to_not_exist/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+- Guardrails mods:
+  - [@turbot/aws-vpc-internet](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/aws/mods/aws-vpc-internet)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/working-with-folders/smart#attach-a-smart-folder-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/smart-folders).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "vpc_elastic_ip_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-internet#/policy/types/elasticIpApproved"
+  # value    = "Check: Approved"
+  value = "Enforce: Delete unapproved if new"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/main.tf
+++ b/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Elastic IPs To Not Exist"
+  description = "Preventing the allocation of Elastic IPs enhances security and cost management by reducing public exposure, minimizing potential attack surfaces, and controlling unnecessary expenses associated with idle IP addresses."
+  akas        = ["aws_vpc_enforce_elastic_ips_to_not_exist"]
+}

--- a/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/policies.tf
+++ b/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/policies.tf
@@ -1,0 +1,14 @@
+# AWS > VPC > Elastic IP > Approved
+resource "turbot_policy_setting" "vpc_elastic_ip_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-internet#/policy/types/elasticIpApproved"
+  value    = "Check: Approved"
+  # value = "Enforce: Delete unapproved if new"
+}
+
+# AWS > VPC > Elastic IP > Approved > Usage
+resource "turbot_policy_setting" "vpc_elastic_ip_approved_usage" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-internet#/policy/types/elasticIpApprovedUsage"
+  value    = "Not approved"
+}

--- a/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/providers.tf
+++ b/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    turbot = {
+      source = "turbot/turbot"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
### Add
- [x] AWS > VPC > Elastic IP - Enforce Elastic IPs To Not Exist
- [x] AWS > VPC > Default VPC- Enforce Default VPCs To Not Exist

### Test Screenshots
#### AWS > VPC > Elastic IP - Enforce Elastic IPs To Not Exist
![image](https://github.com/user-attachments/assets/947c7d32-e564-40f9-9a02-6ca7b6c4b667)
![image](https://github.com/user-attachments/assets/458d4645-fc35-4f8a-a84a-087d251999fa)

####  AWS > VPC > Default VPC- Enforce Default VPCs To Not Exist
![image](https://github.com/user-attachments/assets/9275f2f6-6d58-4185-b0fb-ea13237b5041)
![image](https://github.com/user-attachments/assets/3207874a-45bf-4408-8f00-56fb5fcdae7d)
