### PR TITLE
Add AWS VPC Policy Pack 5

### DIFF
--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/README.md
@@ -3,7 +3,7 @@ categories: ["networking", "security"]
 primary_category: "security"
 ---
 
-# Enforce AWS VPC Default Security Groups to Not Exist
+# Enforce AWS VPC Default Security Groups To Not Exist
 
 Enforcing the non-existence of AWS VPC default security groups is crucial to enhance security by ensuring that all security group rules are explicitly defined and managed, preventing unintended or overly permissive access that could arise from default settings. This control helps maintain a strict security posture and reduces the risk of vulnerabilities due to misconfigurations or the use of default rules that may not align with an organization's security policies.
 
@@ -91,7 +91,7 @@ resource "turbot_policy_setting" "aws_vpc_security_group_approved" {
   resource = turbot_policy_pack.main.id
   type     = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupApproved"
   # value    = "Check: Approved"
-  value    = "Enforce: Delete unapproved"
+  value    = "Enforce: Delete unapproved if new"
 }
 ```
 

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/README.md
@@ -1,0 +1,103 @@
+---
+categories: ["networking", "security"]
+primary_category: "security"
+---
+
+# Enforce AWS VPC Default Security Groups to Not Exist
+
+Enforcing the non-existence of AWS VPC default security groups is crucial to enhance security by ensuring that all security group rules are explicitly defined and managed, preventing unintended or overly permissive access that could arise from default settings. This control helps maintain a strict security posture and reduces the risk of vulnerabilities due to misconfigurations or the use of default rules that may not align with an organization's security policies.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/smart-folders) can help you configure the following settings for VPC security groups:
+
+- Delete default security groups if available
+
+## Documentation
+
+- **[Review Policy settings →](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/policy-packs/enforce_default_security_groups_to_not_exist/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+- Guardrails mods:
+  - [@turbot/aws-vpc-security](https://hub-guardrails-turbot-com-git-development-turbot.vercel.app/aws/mods/aws-vpc-security)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/working-with-folders/smart#attach-a-smart-folder-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/smart-folders).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_vpc_security_group_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupApproved"
+  # value    = "Check: Approved"
+  value    = "Enforce: Delete unapproved"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/main.tf
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/main.tf
@@ -1,5 +1,5 @@
 resource "turbot_policy_pack" "main" {
-  title       = "Enforce AWS VPC Default Security Groups to Not Exist"
+  title       = "Enforce AWS VPC Default Security Groups To Not Exist"
   description = "This measure ensures that all security group rules are explicitly defined and managed, reducing the risk of vulnerabilities due to misconfigurations or overly permissive default settings."
   akas        = ["aws_vpc_enforce_default_security_groups_to_not_exist"]
 }

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/main.tf
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce AWS VPC Default Security Groups to Not Exist"
+  description = "This measure ensures that all security group rules are explicitly defined and managed, reducing the risk of vulnerabilities due to misconfigurations or overly permissive default settings."
+  akas        = ["aws_vpc_enforce_default_security_groups_to_not_exist"]
+}

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/policies.tf
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/policies.tf
@@ -3,7 +3,7 @@ resource "turbot_policy_setting" "aws_vpc_security_group_approved" {
   resource = turbot_policy_pack.main.id
   type     = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupApproved"
   value    = "Check: Approved"
-  # value    = "Enforce: Delete unapproved"
+  # value    = "Enforce: Delete unapproved if new"
 }
 
 # AWS > VPC > Security Group > Approved > Custom
@@ -23,15 +23,23 @@ resource "turbot_policy_setting" "aws_vpc_security_group_approved_custom" {
      {% set data = {
           "title": "Default Security Group",
           "result": "Not approved",
-          "message": "Security Group is the default group"
+          "message": "Default security group is not allowed to exist"
       } -%}
-    
-    {%- else %}
+
+    {%- elif $.resource.name != "default" -%}
+
+     {% set data = {
+          "title": "Default Security Group",
+          "result": "Approved",
+          "message": "Not a default security group"
+      } -%}
+
+    {%- else -%}
 
       {% set data = {
           "title": "Default Security Group",
-          "result": "Approved",
-          "message": "Security Group is not the default group"
+          "result": "Skip",
+          "message": "No data for security group yet"
       } -%}
 
     {%- endif -%}

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/policies.tf
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/policies.tf
@@ -1,0 +1,40 @@
+# AWS > VPC > Security Group > Approved
+resource "turbot_policy_setting" "aws_vpc_security_group_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupApproved"
+  value    = "Check: Approved"
+  # value    = "Enforce: Delete unapproved"
+}
+
+# AWS > VPC > Security Group > Approved > Custom
+resource "turbot_policy_setting" "aws_vpc_security_group_approved_custom" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/aws-vpc-security#/policy/types/securityGroupApprovedCustom"
+  template_input = <<-EOT
+    {   
+      resource {
+        name: get(path: "GroupName")
+      }
+    }
+  EOT
+  template = <<-EOT
+    {%- if $.resource.name == "default" -%}
+
+     {% set data = {
+          "title": "Default Security Group",
+          "result": "Not approved",
+          "message": "Security Group is the default group"
+      } -%}
+    
+    {%- else %}
+
+      {% set data = {
+          "title": "Default Security Group",
+          "result": "Approved",
+          "message": "Security Group is not the default group"
+      } -%}
+
+    {%- endif -%}
+    {{ data | json }}
+  EOT
+}

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/providers.tf
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    turbot = {
+      source = "turbot/turbot"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
### Add
- [x] AWS > VPC > Security Group - Enforce AWS VPC Default Security Groups to Not Exist

### Test Screenshots
![image](https://github.com/user-attachments/assets/c41d836c-dd98-449f-a51f-1b37d4e89afb)
![image](https://github.com/user-attachments/assets/440ce059-65ee-471f-ad4e-d628a41dc19f)
