### PR TITLE
Fix Policy Pack documentation link in Policy Packs

### DIFF
--- a/policy_packs/aws/cis_v300/section1/README.md
+++ b/policy_packs/aws/cis_v300/section1/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section contains recommendations for configuring identity and access management related options.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 1 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 1 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_cis_v300_section1/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/cis_v300/section2/README.md
+++ b/policy_packs/aws/cis_v300/section2/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section contains recommendations for configuring AWS Storage.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 2 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 2 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_cis_v300_section2/settings)**
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/cis_v300/section3/README.md
+++ b/policy_packs/aws/cis_v300/section3/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section contains recommendations for configuring AWS logging features.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 3 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 3 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_cis_v300_section3/settings)**
 
@@ -90,7 +90,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/cis_v300/section4/README.md
+++ b/policy_packs/aws/cis_v300/section4/README.md
@@ -8,7 +8,7 @@ primary_category: "compliance"
 This section contains recommendations for configuring AWS to assist with monitoring and responding to account activities.
 Metric filter-related recommendations in this section are dependent on the Ensure CloudTrail is enabled in all regions and Ensure CloudTrail trails are integrated with CloudWatch Logs recommendation in the Logging section.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 4 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 4 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_cis_v300_section4/settings)**
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/cis_v300/section5/README.md
+++ b/policy_packs/aws/cis_v300/section5/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section contains recommendations for configuring security-related aspects of AWS Virtual Private Cloud (VPC).
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 5 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of AWS CIS benchmark section 5 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_cis_v300_section5/settings)**
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/dms/enforce_replication_instances_to_not_be_publicly_accessible/README.md
+++ b/policy_packs/aws/dms/enforce_replication_instances_to_not_be_publicly_accessible/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing AWS DMS Replication Instances to restrict public access is crucial to protect sensitive data during migration processes. This measure minimizes the risk of unauthorized access, potential data breaches, and ensures compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for DMS replication instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for DMS replication instances:
 
 - Stop/Terminate replication instances which have public access enabled
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/dynamodb/enforce_point_in_time_recovery_is_enabled_for_tables/README.md
+++ b/policy_packs/aws/dynamodb/enforce_point_in_time_recovery_is_enabled_for_tables/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing point-in-time recovery (PITR) for AWS DynamoDB tables is crucial for ensuring data durability and protection against accidental deletions or write errors. This measure allows you to restore DynamoDB tables to any point within the last 35 days, enhancing data recovery capabilities and ensuring compliance with data protection best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for DynamoDB tables:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for DynamoDB tables:
 
 - Enable Point-in-Time recovery
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/deny_unapproved_amis_publishers_for_instances/README.md
+++ b/policy_packs/aws/ec2/deny_unapproved_amis_publishers_for_instances/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Denying AWS EC2 instances with unapproved AMIs and/or publisher accounts is essential to maintain a secure and controlled environment. This prevents the use of potentially vulnerable or malicious images, ensuring that only vetted and compliant resources are deployed, thereby reducing security risks and maintaining compliance with organizational policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Enforce a lockdown IAM policy via Guardrails to deny launching EC2 instances with unapproved AMIs and/or publishers
 - Set the AMI IDs that are approved for use
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_amis_to_be_shared_with_trusted_accounts/README.md
+++ b/policy_packs/aws/ec2/enforce_amis_to_be_shared_with_trusted_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing EC2 AMIs to be shared only with trusted accounts is crucial for maintaining security and compliance, as it ensures that sensitive or proprietary configurations and data are only accessible to authorized users, reducing the risk of unauthorized access and potential data breaches. This control helps safeguard the integrity and confidentiality of the systems and data deployed in AWS environments.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 AMIs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 AMIs:
 
 - Set trusted accounts
 - Revoke untrusted access from AMIs
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_amis_used_by_instances_to_use_specific_approved_tags/README.md
+++ b/policy_packs/aws/ec2/enforce_amis_used_by_instances_to_use_specific_approved_tags/README.md
@@ -7,7 +7,7 @@ primary_category: "tagging"
 
 Enforcing that AWS EC2 AMIs used by instances have specific approved tags is vital for maintaining resource organization, compliance, and effective management. This practice ensures that all instances are easily identifiable based on their purpose, environment, and other criteria, facilitating cost tracking, security management, and adherence to organizational policies and best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Set a list of approved tags for AMIs
 - Stop/Terminate instances if corresponding AMIs do not use specified tags
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_approved_amis_publishers_for_instances/README.md
+++ b/policy_packs/aws/ec2/enforce_approved_amis_publishers_for_instances/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing AWS EC2 instances to use approved AMIs and/or publisher accounts is vital for maintaining a secure and standardized environment. This practice ensures that only trusted, validated images are used, reducing the risk of security vulnerabilities and ensuring compliance with organizational policies and security standards.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Stop/Terminate instances that do not use approved AMIs and/or publisher accounts
 - Set the AMI IDs that are approved for use
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_ebs_volumes_to_be_attached_to_instances/README.md
+++ b/policy_packs/aws/ec2/enforce_ebs_volumes_to_be_attached_to_instances/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing that AWS EC2 EBS volumes are attached to instances is essential for optimizing resource usage and ensuring security. This practice helps avoid unnecessary costs associated with unattached volumes, reduces the risk of data exposure, and ensures that all storage resources are actively managed and utilized as intended.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EBS volumes:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EBS volumes:
 
 - Detach, snapshot and delete EBS volumes that are not attached to instances
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_ebs_volumes_to_not_be_older_than_90_days/README.md
+++ b/policy_packs/aws/ec2/enforce_ebs_volumes_to_not_be_older_than_90_days/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Automatically deleting AWS EC2 volumes that have been active for more than 90 days is crucial for resource optimization and cost management. This measure helps in ensuring that long-running volumes are periodically reviewed and terminated if no longer needed, thereby reducing unnecessary costs and improving overall resource utilization.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 volumes:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 volumes:
 
 - Detach, snapshot and delete volumes that are older than 90 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_ebs_volumes_to_use_specific_volume_types/README.md
+++ b/policy_packs/aws/ec2/enforce_ebs_volumes_to_use_specific_volume_types/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing AWS EC2 EBS volumes to use specific volume types is crucial for optimizing performance, cost, and security. By ensuring that only approved volume types are used, organizations can maintain consistent performance standards, manage expenses effectively, and mitigate risks associated with unauthorized or inappropriate storage configurations.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EBS volumes:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EBS volumes:
 
 - Set a list of specific volume types that are approved for use
 - Detach, snapshot and delete volumes that do not belong to the list of approved volume types
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_enable_termination_protection_for_instances/README.md
+++ b/policy_packs/aws/ec2/enforce_enable_termination_protection_for_instances/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing termination protection for AWS EC2 instances is crucial because it prevents accidental or unauthorized termination of instances, which can lead to data loss, application downtime, and potential security vulnerabilities. By enabling this protection, organizations can ensure the continuity and integrity of their critical workloads and services running on AWS.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Enable termination protection
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_encryption_at_rest_is_enabled_for_ebs_volumes/README.md
+++ b/policy_packs/aws/ec2/enforce_encryption_at_rest_is_enabled_for_ebs_volumes/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption at rest for AWS EBS volumes is critical to protect sensitive data from unauthorized access and potential breaches. This measure ensures that data stored on EBS volumes is encrypted, thereby enhancing data security and compliance with regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EBS volumes:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EBS volumes:
 
 - Detach, snapshot and delete volumes that do not have Encryption at Rest enabled
 - Set Customer Managed Key which should be used to encrypt volumes
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_encryption_by_default_is_enabled_for_ebs_volumes/README.md
+++ b/policy_packs/aws/ec2/enforce_encryption_by_default_is_enabled_for_ebs_volumes/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption by default for AWS EC2 EBS volumes is essential for protecting sensitive data at rest. This measure ensures that all newly created EBS volumes are automatically encrypted, reducing the risk of unauthorized data access and breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 EBS volumes:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 EBS volumes:
 
 - Enforce encryption by default in a region
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_imdsv2_for_instances/README.md
+++ b/policy_packs/aws/ec2/enforce_imdsv2_for_instances/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) for AWS EC2 instances enhances security by requiring session-based authentication to access instance metadata, mitigating the risk of unauthorized metadata exposure through vulnerabilities like SSRF (Server-Side Request Forgery). This helps ensure that only authorized applications and users can retrieve sensitive instance data.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Enforce IMDSv2, which requires session-based authentication
 - Set the `PUT` response hop limit to restrict IMDS access
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_instances_to_not_be_older_than_90_days/README.md
+++ b/policy_packs/aws/ec2/enforce_instances_to_not_be_older_than_90_days/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Automatically deleting AWS EC2 instances that have been running for more than 90 days is crucial for resource optimization and cost management. This measure helps in ensuring that long-running instances are periodically reviewed and terminated if no longer needed, thereby reducing unnecessary costs and improving overall resource utilization.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Terminate instances that are older than 90 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_instances_to_not_have_internet_access_via_subnets/README.md
+++ b/policy_packs/aws/ec2/enforce_instances_to_not_have_internet_access_via_subnets/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Enforcing that AWS EC2 instances do not have internet access via subnets is critical for maintaining a secure and controlled network environment. This measure ensures that instances are isolated from the internet, reducing the risk of unauthorized access and potential data breaches, and enhancing security by restricting outbound traffic to approved and monitored channels.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Stop/Terminate instances that have internet access via subnets
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_instances_to_use_specific_instance_types/README.md
+++ b/policy_packs/aws/ec2/enforce_instances_to_use_specific_instance_types/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing specific AWS EC2 instance types ensures that deployed resources align with performance, cost, and compliance requirements. This control helps optimize resource utilization, manage expenses, and maintain consistent security and operational standards across the cloud environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 instances:
 
 - Set a list of specific instance types that are approved for use
 - Stop/Terminate instances that do not belong to the list of approved instance types
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_snapshots_to_be_shared_with_trusted_accounts/README.md
+++ b/policy_packs/aws/ec2/enforce_snapshots_to_be_shared_with_trusted_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing EC2 snapshots to be shared only with trusted accounts is crucial for maintaining data security and compliance. This practice ensures that sensitive information is protected from unauthorized access, reducing the risk of data breaches and maintaining the integrity of your cloud environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 snapshots:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 snapshots:
 
 - Set trusted accounts
 - Revoke untrusted access from snapshots
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_snapshots_to_not_be_older_than_60_days/README.md
+++ b/policy_packs/aws/ec2/enforce_snapshots_to_not_be_older_than_60_days/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Automatically deleting AWS EC2 snapshots that have been active for more than 60 days is crucial for resource optimization and cost management. This measure helps in ensuring that old snapshots are periodically reviewed and deleted if no longer needed, thereby reducing unnecessary storage costs and improving overall resource management.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 snapshots:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 snapshots:
 
 - Delete snapshots that are older than 60 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_tags_on_amis_if_they_are_older_than_14_days/README.md
+++ b/policy_packs/aws/ec2/enforce_tags_on_amis_if_they_are_older_than_14_days/README.md
@@ -7,7 +7,7 @@ primary_category: "tagging"
 
 Enforcing tags on AMIs if they are older than 14 days is important for maintaining effective resource management and tracking. This practice ensures that aged AMIs are properly identified and classified, facilitating their management, compliance with organizational policies, and aiding in decisions related to their retention or deprecation.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EC2 AMIs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EC2 AMIs:
 
 - Set tag `termination: true` if AMI is older than 14 days
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ec2/enforce_tls_1_2_ssl_policy_for_classic_load_balancer_listeners/README.md
+++ b/policy_packs/aws/ec2/enforce_tls_1_2_ssl_policy_for_classic_load_balancer_listeners/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Ensuring that AWS EC2 Classic Load Balancer listeners use SSL policies with TLS 1.2 or greater for any traffic traveling outside of the VPC is crucial for maintaining secure communications. This measure helps in protecting data in transit by enforcing stronger encryption standards, thereby reducing the risk of data breaches and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Classic Load Balancer listeners:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Classic Load Balancer listeners:
 
 - Set SSL policy `ELBSecurityPolicy-TLS-1-2-2017-01` by default
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ecr/enforce_scan_on_push_is_enabled_for_repositories/README.md
+++ b/policy_packs/aws/ecr/enforce_scan_on_push_is_enabled_for_repositories/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing scan on push for AWS ECR (Elastic Container Registry) repositories is crucial for ensuring the security and integrity of container images. This control helps detect vulnerabilities and security issues in images before they are deployed, reducing the risk of running compromised or insecure containers in your environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for ECR repositories:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for ECR repositories:
 
 - Enable scan on push setting
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/efs/enforce_encryption_at_rest_is_enabled_for_file_systems/README.md
+++ b/policy_packs/aws/efs/enforce_encryption_at_rest_is_enabled_for_file_systems/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption at rest for AWS EFS File Systems is crucial because it ensures that all data stored within the file system is automatically encrypted, protecting it from unauthorized access and potential data breaches. This measure helps maintain data confidentiality and integrity, meeting compliance requirements and safeguarding sensitive information.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for EFS file systems:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for EFS file systems:
 
 - Delete file systems that do not have Encryption at Rest enabled
 - Set Customer Managed Key which should be used to encrypt file systems
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/guardduty/enforce_detectors_have_memberships_to_specific_accounts/README.md
+++ b/policy_packs/aws/guardduty/enforce_detectors_have_memberships_to_specific_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing that AWS GuardDuty detectors have membership only to specific accounts is vital for maintaining a controlled and secure threat detection environment. This measure ensures that GuardDuty findings and data are shared only with authorized accounts, enhancing security by preventing unauthorized access to sensitive security information and ensuring compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for GuardDuty detectors:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GuardDuty detectors:
 
 - Set a list of approved accounts
 - Delete detectors if they do not belong to the approved list of accounts
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/guardrails/enable_event_poller/README.md
+++ b/policy_packs/aws/guardrails/enable_event_poller/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 The Guardrails Event Poller is an alternative to the Event Handlers, and is a polling mechanism for obtaining relevant events from AWS and updating CMDB.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for AWS Accounts in Guardrails:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for AWS Accounts in Guardrails:
 
 - Set a polling interval, i.e. the frequency to poll events from AWS
 - Set a polling interval window
@@ -75,4 +75,4 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).

--- a/policy_packs/aws/guardrails/enable_global_event_handlers/README.md
+++ b/policy_packs/aws/guardrails/enable_global_event_handlers/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 The Guardrails Event Handlers are responsible for conveying events from AWS CloudTrail back to Guardrails for processing. This is a requirement for Guardrails to process and respond in real-time.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable Global Event Handlers for AWS Accounts in Guardrails.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable Global Event Handlers for AWS Accounts in Guardrails.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_guardrails_enable_global_event_handlers/settings)**
 
@@ -89,7 +89,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/guardrails/enable_iam_service_roles/README.md
+++ b/policy_packs/aws/guardrails/enable_iam_service_roles/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enablement of AWS IAM service roles is critical for securely delegating permissions to AWS services. This measure ensures that service roles are properly configured and used, allowing AWS services to interact with your resources securely, minimizing the risk of unauthorized actions, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following for service roles:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following for service roles:
 
 - Create IAM service role for configuration recording
 - Create IAM service role for default EC2 instance
@@ -82,7 +82,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/guardrails/enable_multi_region_cloudtrail_trails/README.md
+++ b/policy_packs/aws/guardrails/enable_multi_region_cloudtrail_trails/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 Enabling multi-region CloudTrail trails in AWS accounts is crucial for achieving comprehensive visibility and auditability of API activity across all regions. This ensures that all actions taken within your AWS environment are consistently logged, enhancing security monitoring, supporting incident response, and ensuring compliance with regulatory requirements and best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable multi-region CloudTrail trails in AWS Accounts.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable multi-region CloudTrail trails in AWS Accounts.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_guardrails_enable_multi_region_cloudtrail_trails/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/guardrails/enable_regional_event_handlers/README.md
+++ b/policy_packs/aws/guardrails/enable_regional_event_handlers/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 The Guardrails Event Handlers are responsible for conveying events from AWS CloudTrail back to Guardrails for processing. This is a requirement for Guardrails to process and respond in real-time.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable regional [Event Handlers](https://turbot.com/guardrails/docs/integrations/aws/event-handlers) for AWS Accounts in Guardrails.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable regional [Event Handlers](https://turbot.com/guardrails/docs/integrations/aws/event-handlers) for AWS Accounts in Guardrails.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_guardrails_enable_regional_event_handlers/settings)**
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/guardrails/enable_reporting_for_cis_v300/README.md
+++ b/policy_packs/aws/guardrails/enable_reporting_for_cis_v300/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enabling AWS CIS v3.0.0 is essential for ensuring that your AWS environment adheres to industry-recognized security best practices. This provides a robust framework for identifying and mitigating security risks, enhancing compliance with regulatory requirements, and protecting sensitive data by automatically enforcing the security configurations recommended by the CIS benchmarks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable AWS CIS v3.0.0 reporting with and without attestation controls in Guardrails.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable AWS CIS v3.0.0 reporting with and without attestation controls in Guardrails.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_guardrails_enable_reporting_for_cis_v300/settings)**
 
@@ -72,7 +72,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 > [!TIP]
 > You can also update the policy settings in this policy pack directly in the Guardrails console.

--- a/policy_packs/aws/iam/check_mfa_is_enabled_for_root_accounts/README.md
+++ b/policy_packs/aws/iam/check_mfa_is_enabled_for_root_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Ensuring Multi-Factor Authentication (MFA) is enabled for AWS IAM root accounts is critical as it provides an additional layer of security beyond just a password, significantly reducing the risk of unauthorized access. This protection helps prevent potential security breaches and enhances overall account security by requiring a second form of verification.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM root accounts:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM root accounts:
 
 - Check and alarm if root accounts do not have MFA enabled
 
@@ -75,4 +75,4 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).

--- a/policy_packs/aws/iam/deny_all_iam_actions_from_unapproved_networks/README.md
+++ b/policy_packs/aws/iam/deny_all_iam_actions_from_unapproved_networks/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Denying all AWS IAM actions from unapproved networks is vital for protecting your AWS environment from unauthorized access. This measure ensures that IAM actions, such as creating, modifying, or deleting resources, can only be performed from trusted and approved networks, reducing the risk of malicious activity and enhancing overall security and compliance with best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM:
 
 - Create an IAM Boundary policy to allow IAM actions only to RFC 1918 CIDR ranges
 
@@ -78,7 +78,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/iam/enforce_access_keys_to_not_be_older_than_90_days/README.md
+++ b/policy_packs/aws/iam/enforce_access_keys_to_not_be_older_than_90_days/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing AWS IAM access keys to not be older than 90 days is important because it reduces the risk of compromised credentials by ensuring keys are regularly rotated. Regular key rotation minimizes exposure time for potentially compromised keys, enhancing the security posture and reducing the likelihood of unauthorized access.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM access keys:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM access keys:
 
 - Deactivate/Delete access keys that are older than 90 days
 
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/iam/enforce_account_password_policy_settings/README.md
+++ b/policy_packs/aws/iam/enforce_account_password_policy_settings/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing AWS IAM account password policy settings is crucial for ensuring strong authentication and enhancing account security. This measure ensures that passwords meet specific complexity, length, and rotation requirements, reducing the risk of unauthorized access and aligning with best practices and regulatory compliance.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM account password policy:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM account password policy:
 
 - Enable Allow Users to Change
 - Enable Hard Expiry
@@ -83,7 +83,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/iam/enforce_mfa_is_enabled_for_users/README.md
+++ b/policy_packs/aws/iam/enforce_mfa_is_enabled_for_users/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Multi-Factor Authentication (MFA) for AWS IAM users is crucial for enhancing account security. This measure adds an extra layer of protection by requiring a second form of verification, reducing the risk of unauthorized access even if credentials are compromised, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM users:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM users:
 
 - Delete users that do not have MFA enabled
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/iam/enforce_policies_to_not_have_admin_privileges/README.md
+++ b/policy_packs/aws/iam/enforce_policies_to_not_have_admin_privileges/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing AWS IAM policies to not have admin privileges is essential to adhere to the principle of least privilege. This control minimizes the risk of accidental or intentional misuse of powerful permissions, reducing the potential impact of security breaches by ensuring that users and roles have only the permissions necessary to perform their specific tasks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM Policies:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM Policies:
 
 - Delete policies that allow administrative access on any resource
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/iam/enforce_roles_to_have_trusted_access/README.md
+++ b/policy_packs/aws/iam/enforce_roles_to_have_trusted_access/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing that AWS IAM roles have trusted access is essential for ensuring that only authorized entities can assume roles and access resources. This measure restricts role assumption to trusted accounts and services, reducing the risk of unauthorized access, enhancing security, and ensuring compliance with organizational policies and best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM roles:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM roles:
 
 - Set trusted accounts
 - Set trusted services
@@ -79,7 +79,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/kms/enforce_keys_to_not_allow_unapproved_action_permissions/README.md
+++ b/policy_packs/aws/kms/enforce_keys_to_not_allow_unapproved_action_permissions/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS KMS keys do not allow unapproved action permissions is crucial for maintaining the security and integrity of encrypted data. This measure ensures that only authorized actions can be performed on KMS keys, reducing the risk of unauthorized access and misuse, thereby enhancing overall security and compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for KMS keys:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for KMS keys:
 
 - Revoke policy statements which allow below KMS actions:
   - Access via Lambda service
@@ -92,7 +92,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/kms/enforce_rotation_is_enabled_for_keys/README.md
+++ b/policy_packs/aws/kms/enforce_rotation_is_enabled_for_keys/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing rotation for AWS KMS keys is essential for maintaining the security and integrity of encrypted data. Regular key rotation ensures that cryptographic keys are periodically updated, reducing the risk of key compromise and enhancing overall security, while also ensuring compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for KMS keys:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for KMS keys:
 
 - Enable rotation
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/lambda/enforce_functions_to_be_in_vpc/README.md
+++ b/policy_packs/aws/lambda/enforce_functions_to_be_in_vpc/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS Lambda functions are in a VPC is essential for enhancing the security and control of serverless applications. This measure ensures that Lambda functions can interact securely with resources within the VPC, utilize VPC security groups and network ACLs, and prevent unauthorized access by restricting outbound internet access, thereby aligning with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Lambda functions:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Lambda functions:
 
 - Delete functions that are not in a VPC
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/lambda/enforce_functions_to_restrict_public_access/README.md
+++ b/policy_packs/aws/lambda/enforce_functions_to_restrict_public_access/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing AWS Lambda functions to restrict public access is vital to prevent unauthorized users from invoking functions, which can lead to security vulnerabilities and potential data breaches. By limiting access, you ensure that only authorized entities can execute the functions, thereby maintaining the integrity and confidentiality of your applications and data.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Lambda functions:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Lambda functions:
 
 - Revoke untrusted access from the function's IAM resource policy
 - Set trusted accounts for the IAM resource policy
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/lambda/enforce_functions_to_use_specific_approved_tags/README.md
+++ b/policy_packs/aws/lambda/enforce_functions_to_use_specific_approved_tags/README.md
@@ -7,7 +7,7 @@ primary_category: "tagging"
 
 Enforcing that AWS Lambda functions use specific approved tags is crucial for maintaining organized and compliant cloud environments. This practice ensures proper resource management, cost tracking, and compliance with organizational policies by enabling the identification and classification of Lambda functions based on their purpose, environment, and other relevant criteria.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Lambda functions:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Lambda functions:
 
 - Set a list of approved tags
 - Delete functions if specified tags are not present
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/logs/enforce_encryption_at_rest_is_enabled_for_log_groups/README.md
+++ b/policy_packs/aws/logs/enforce_encryption_at_rest_is_enabled_for_log_groups/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Ensuring that CloudWatch log groups are encrypted at rest is crucial for enhancing security. This measure helps protect log data by encrypting it, thereby reducing the risk of unauthorized access and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for CloudWatch log groups:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for CloudWatch log groups:
 
 - Set Customer Managed Key to be used for encryption
 - Enable Encryption at Rest for log groups
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/rds/enforce_db_cluster_manual_snapshots_be_shared_with_approved_accounts/README.md
+++ b/policy_packs/aws/rds/enforce_db_cluster_manual_snapshots_be_shared_with_approved_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS RDS DB cluster manual snapshots are shared only with approved accounts is crucial for maintaining data security and access control. This measure ensures that sensitive data within snapshots is accessible only to authorized accounts, reducing the risk of unauthorized access and data breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for RDS DB cluster manual snapshots:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for RDS DB cluster manual snapshots:
 
 - Set a list of trusted accounts to which the snapshots can be shared
 - Delete snapshots that are shared with untrusted accounts
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/rds/enforce_db_instances_to_not_be_publicly_accessible/README.md
+++ b/policy_packs/aws/rds/enforce_db_instances_to_not_be_publicly_accessible/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS RDS DB instances are not publicly accessible is crucial for protecting sensitive data and ensuring database security. This measure prevents unauthorized internet access to your RDS instances, reducing the risk of data breaches and enhancing compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for RDS DB instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for RDS DB instances:
 
 - Enforce DB instances to not be publicly accessible
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/rds/enforce_db_instances_to_use_specific_engines_and_instance_classes/README.md
+++ b/policy_packs/aws/rds/enforce_db_instances_to_use_specific_engines_and_instance_classes/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing that AWS RDS DB instances use specific engines and instance classes is essential for maintaining a standardized, secure, and optimized database environment. This measure ensures that RDS instances comply with organizational policies, meet performance and security requirements, and align with best practices for cost management and resource utilization.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for RDS instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for RDS instances:
 
 - Set a list of approved engines
 - Set a list of approved instance classes
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/rds/enforce_encryption_at_rest_is_enabled_for_db_instances/README.md
+++ b/policy_packs/aws/rds/enforce_encryption_at_rest_is_enabled_for_db_instances/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption at rest for RDS DB instances is critical for safeguarding sensitive data stored in your databases. This measure ensures that all data is encrypted when stored, protecting it from unauthorized access and potential breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for RDS instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for RDS instances:
 
 - Set Customer Managed Key to be used for encryption
 - Stop/Terminate instances that are not encrypted
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/redshift/enforce_encryption_in_transit_is_enabled_for_clusters/README.md
+++ b/policy_packs/aws/redshift/enforce_encryption_in_transit_is_enabled_for_clusters/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption in transit for AWS Redshift clusters is crucial for protecting data as it moves between clients and the Redshift service. This measure ensures that all data is encrypted during transmission, safeguarding it from interception and unauthorized access, thereby enhancing overall security and compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Redshift clusters:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Redshift clusters:
 
 - Enable Encryption in Transit by changing the `require_ssl` parameter of the attached parameter group. This change will also trigger **reboot** of the cluster.
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/redshift/enforce_manual_cluster_snapshots_be_shared_with_trusted_accounts/README.md
+++ b/policy_packs/aws/redshift/enforce_manual_cluster_snapshots_be_shared_with_trusted_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS Redshift manual cluster snapshots are shared only with trusted accounts is vital for maintaining data security and access control. This measure ensures that sensitive data within snapshots is accessible only to authorized accounts, reducing the risk of unauthorized access and data breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Redshift manual cluster snapshots:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Redshift manual cluster snapshots:
 
 - Set trusted accounts
 - Revoke untrusted access from snapshots
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_access_logging_is_enabled_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_access_logging_is_enabled_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 Ensuring that S3 bucket access logging is enabled and follows a specific naming convention is crucial for enhanced security and auditing. This measure helps in tracking access to S3 buckets, thereby improving visibility and accountability for data access and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Set a logging bucket name
 - Set a logging bucket prefix
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_approved_replication_accounts_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_approved_replication_accounts_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing the use of approved replication accounts for buckets is essential for maintaining control over data replication processes. This measure ensures that only trusted and authorized accounts are used for replicating data, reducing the risk of unauthorized data access or replication, and enhancing overall data security and compliance with organizational policies and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Set approved replication accounts list
 - Delete buckets that are emptry and do not use approved replication accounts
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_block_public_access_is_enabled_for_accounts/README.md
+++ b/policy_packs/aws/s3/enforce_block_public_access_is_enabled_for_accounts/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Block Public Access for AWS S3 accounts is crucial to prevent unauthorized access and exposure of sensitive data at the S3 account level. This measure ensures that all S3 buckets within an account have restricted access settings, minimizing the risk of data breaches and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 accounts:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 accounts:
 
 - Enforce Block Public Access, which would prevent unauthorized access
 - Set individual Block Public Access setting for S3 accounts
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_block_public_access_is_enabled_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_block_public_access_is_enabled_for_buckets/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing Block Public Access for AWS S3 buckets is essential to protect sensitive data from unauthorized access and exposure. This measure ensures that individual S3 buckets are configured to restrict public access, thereby reducing the risk of data breaches and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Enforce Block Public Access, which would prevent unauthorized access
 - Set individual Block Public Access setting for buckets
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_cloudfront_distribution_for_buckets_is_secured/README.md
+++ b/policy_packs/aws/s3/enforce_cloudfront_distribution_for_buckets_is_secured/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that CloudFront distributions for AWS S3 buckets are secured is crucial for protecting data and ensuring secure content delivery. This measure ensures that security best practices, such as HTTPS and access controls are applied to CloudFront distributions, reducing the risk of unauthorized access and data breaches while ensuring compliance with regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Delete empty buckets with CloudFront Distributions not secured
 
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_creator_and_creationtime_tags_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_creator_and_creationtime_tags_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "tagging"
 
 Enforcing Creator and Creation Time tags for AWS S3 Buckets is important for effective tracking and auditing of data assets. These tags provide critical metadata that helps in identifying the origin and creation time of S3 buckets, enhancing accountability and facilitating compliance with data governance policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Enforce `creator` and `creationTime` tags
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_encryption_at_rest_is_enabled_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_encryption_at_rest_is_enabled_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption at rest for AWS S3 buckets is crucial to safeguard sensitive data stored in the cloud. This ensures that all data within S3 buckets is encrypted, protecting it from unauthorized access and potential breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Enforce Encryption at Rest, to safeguard sensitive data in buckets
 - Set the Customer Managed Key to be used to encrypt data in buckets
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_encryption_in_transit_is_enabled_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_encryption_in_transit_is_enabled_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption in transit for AWS S3 buckets is vital to protect data as it moves between clients and the S3 service. This measure ensures that data is encrypted during transmission, safeguarding it from interception and unauthorized access, thereby enhancing security and compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Enforce Encryption in Transit, to protect data as it moves between clients and the S3 service
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_name_for_buckets_is_dns_compliant/README.md
+++ b/policy_packs/aws/s3/enforce_name_for_buckets_is_dns_compliant/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 Enforcing that AWS S3 bucket names are DNS compliant is essential for ensuring compatibility with internet standards and services. This measure ensures that bucket names adhere to DNS naming conventions, preventing issues with accessibility and interoperability, and ensuring smooth integration with various AWS services and applications.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Delete empty buckets with names that are not DNS complaint
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_trusted_access_for_acls_on_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_trusted_access_for_acls_on_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing trusted access for ACLs (Access Control Lists) on AWS S3 buckets is critical for ensuring that only authorized users and services have access to your data. This measure helps prevent unauthorized access, data breaches, and ensures that permissions are tightly controlled and aligned with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Set trusted ACL groups
 - Set trusted ACL Canonical IDs
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_trusted_access_for_policies_on_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_trusted_access_for_policies_on_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Ensuring that S3 bucket policies do not allow access to all AWS users or non-trusted AWS accounts is crucial for enhancing security. This measure helps protect sensitive data by restricting bucket access to trusted accounts only, thereby reducing the risk of unauthorized access and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Set trusted accounts
 - Set trusted services
@@ -81,7 +81,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/s3/enforce_versioning_is_enabled_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_versioning_is_enabled_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing versioning for AWS S3 buckets is crucial because it provides data protection by maintaining multiple versions of objects, enabling the recovery of previous versions in case of accidental deletions or overwrites. This ensures data integrity, facilitates disaster recovery, and supports compliance with data retention policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for S3 buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
 
 - Enable versioning
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/sns/enforce_encryption_at_rest_is_enabled_for_topics/README.md
+++ b/policy_packs/aws/sns/enforce_encryption_at_rest_is_enabled_for_topics/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing Encryption at Rest for AWS SNS Topics is critical for ensuring that sensitive messages remain secure and protected from unauthorized access. This control helps safeguard data confidentiality by automatically encrypting all messages stored in SNS topics, thereby reducing the risk of data breaches and complying with regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for SNS topics:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for SNS topics:
 
 - Set the Customer Managed Key to be used for encryption
 - Enforce Encryption at Rest via AWS managed key or a customer managed key
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/sqs/enforce_queues_to_have_trusted_access/README.md
+++ b/policy_packs/aws/sqs/enforce_queues_to_have_trusted_access/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing trusted access for AWS SQS queues is essential for maintaining secure and controlled message handling within your applications. This measure ensures that only authorized entities can interact with your SQS queues, reducing the risk of unauthorized access, message tampering, and potential data breaches, while ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for SQS queues:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for SQS queues:
 
 - Set trusted accounts
 - Set trusted services
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/ssm/enforce_install_packages_on_ec2_instances_using_ssm_package_installer/README.md
+++ b/policy_packs/aws/ssm/enforce_install_packages_on_ec2_instances_using_ssm_package_installer/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing the installation of packages on AWS EC2 instances using the SSM Package Installer is crucial for maintaining a consistent, secure, and automated software deployment process. This measure ensures that all package installations are managed and logged through AWS Systems Manager, enhancing security, compliance, and operational efficiency by providing centralized control and monitoring of software installations.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) is designed to allow package installation on instances with or without direct access to original package source and can help you configure the following settings for SSM documents:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) is designed to allow package installation on instances with or without direct access to original package source and can help you configure the following settings for SSM documents:
 
 - Set the region ARN where the SSM resources will be deployed
 - Set the IAM role ARN to be used by SSM to run documents
@@ -143,7 +143,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_block_public_access_for_security_groups/README.md
+++ b/policy_packs/aws/vpc/enforce_block_public_access_for_security_groups/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Block Public Access for AWS VPC security groups is essential to prevent unauthorized access and exposure of sensitive data to the public internet. This measure ensures that ingress rules for ports 22 (SSH) and -1 (all ports) from 0.0.0.0/0 and ::/0 are blocked, minimizing the risk of security breaches and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC security groups:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC security groups:
 
 - Reject and revoke unapproved rules that allow ingress for ports 22 (SSH) and -1 (all ports) from 0.0.0.0/0 and ::/0.
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_block_unapproved_network_access_for_security_groups/README.md
+++ b/policy_packs/aws/vpc/enforce_block_unapproved_network_access_for_security_groups/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Enforcing Block Unapproved Network Access for AWS VPC security groups is crucial to ensure that only specific, approved ingress rules are allowed. This measure restricts access to only the necessary ports (22, 443, 3389) from individual IP addresses with a bitmask of /32 and specific CIDRs. By doing so, it minimizes the risk of unauthorized access and potential security breaches, thereby ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC security groups:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC security groups:
 
 - Allow only specific ports (22, 443, 3389) for ingress rules.
 - Set access to individual IP addresses with a bitmask of `/32`.
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_allow_any_access/README.md
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_allow_any_access/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS VPC default security groups do not allow any access is crucial because it prevents unintended network exposure and potential security vulnerabilities. Default security groups, if left open, could inadvertently permit unrestricted inbound and outbound traffic, leading to unauthorized access and exploitation of resources within the VPC.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for default VPC security groups:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for default VPC security groups:
 
 - Revoke all ingress rules associated with the security group
 - Revoke all egress rules associated with the security group
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_default_security_groups_to_not_exist/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing the non-existence of AWS VPC default security groups is crucial to enhance security by ensuring that all security group rules are explicitly defined and managed, preventing unintended or overly permissive access that could arise from default settings. This control helps maintain a strict security posture and reduces the risk of vulnerabilities due to misconfigurations or the use of default rules that may not align with an organization's security policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC security groups:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC security groups:
 
 - Delete default security groups if available
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_default_vpcs_to_not_exist/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that Default AWS VPCs do not exist is crucial for maintaining network security and control, as default VPCs often come with pre-configured settings that might not align with an organization's specific security and compliance requirements. By removing Default VPCs, administrators can ensure that all VPCs are created with custom configurations tailored to their security policies and operational needs, reducing the risk of unintended exposure or misconfiguration.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Default VPCs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Default VPCs:
 
 - Delete Default VPCs if available
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_elastic_ips_to_not_be_unassociated/README.md
+++ b/policy_packs/aws/vpc/enforce_elastic_ips_to_not_be_unassociated/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing that AWS VPC Elastic IPs are not unassociated is crucial for optimizing resource usage and maintaining a secure environment. This practice ensures that all allocated Elastic IPs are actively used, reducing the risk of unnecessary costs, potential IP misconfigurations, and security vulnerabilities associated with unused IP addresses.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC elastic IPs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC elastic IPs:
 
 - Delete non associated elastic IPs
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_elastic_ips_to_not_exist/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS VPC Elastic IPs do not exist is essential for maintaining a highly secure network environment by preventing unnecessary public IP addresses. This measure minimizes the attack surface by eliminating potential entry points for unauthorized access and reducing the risk of data breaches, thereby ensuring compliance with security best practices and organizational policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC elastic ips:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC elastic ips:
 
 - Delete elastic IPs if available
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_enable_flow_logging_to_cloudwatch_log_groups_for_vpcs/README.md
+++ b/policy_packs/aws/vpc/enforce_enable_flow_logging_to_cloudwatch_log_groups_for_vpcs/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 Enforcing flow logging to CloudWatch Log Groups for VPCs is essential for real-time monitoring and analysis of network traffic within your VPCs. This measure ensures that all network flow logs are captured and stored in CloudWatch Log Groups, enabling efficient detection of anomalous activity, troubleshooting of network issues, and compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPCs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPCs:
 
 - Set CloudWatch log group name to which flow logging would be configured
 - Set IAM role name that flow logging will assume to write logs to CloudWatch log group
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_enable_flow_logging_to_s3_buckets_for_vpcs/README.md
+++ b/policy_packs/aws/vpc/enforce_enable_flow_logging_to_s3_buckets_for_vpcs/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 Enforcing flow logging to S3 buckets for AWS VPCs is crucial for maintaining comprehensive visibility and auditability of network traffic within your VPCs. This measure ensures that all network flow logs are stored securely in S3 buckets, facilitating detailed analysis, anomaly detection, and compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPCs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPCs:
 
 - Set S3 bucket name to which flow logging would be configured
 - Enable flow logging to S3 bucket
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_internet_gateways_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_internet_gateways_to_not_exist/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that AWS VPC Internet Gateways do not exist is essential for maintaining a highly secure network environment by preventing direct internet access to and from your VPCs. This measure minimizes the attack surface, reduces the risk of unauthorized access and potential data breaches, and ensures that all external connectivity is tightly controlled and monitored through alternative, more secure methods.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC internet gateways:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC internet gateways:
 
 - Detach/Delete internet gateways if available
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_nat_gateways_to_not_exist/README.md
+++ b/policy_packs/aws/vpc/enforce_nat_gateways_to_not_exist/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Enforcing that NAT Gateways do not exist in your AWS environment is crucial for ensuring that private instances remain completely isolated from the internet. This measure prevents any outbound internet traffic from private subnets, reducing the risk of data exfiltration, unauthorized access, and potential security breaches, thereby enhancing overall network security and compliance with stringent security policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC nat gateways:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC nat gateways:
 
 - Delete Nat Gateways if available
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/aws/vpc/enforce_vpcs_to_have_transit_gateways_attached/README.md
+++ b/policy_packs/aws/vpc/enforce_vpcs_to_have_transit_gateways_attached/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing AWS VPCs to have a Transit Gateway attached is crucial for ensuring secure and efficient inter-VPC communication and centralized network management. This practice enhances network scalability, simplifies complex network architectures, and improves overall security by providing a single point of control for routing and connectivity.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPCs:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPCs:
 
 - Delete VPCs that do not have a transit gateway attached
 
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/aks/enforce_enable_rbac_for_managed_clusters/README.md
+++ b/policy_packs/azure/aks/enforce_enable_rbac_for_managed_clusters/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing Role-Based Access Control (RBAC) for Azure AKS managed clusters is crucial as it ensures that only authorized users and applications can perform actions within clusters. This granular control enhances security by preventing unauthorized access and modifications, thereby protecting the integrity and availability of the applications and services running in the Kubernetes environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for AKS managed clusters:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for AKS managed clusters:
 
 - Terminate clusters that do not have RBAC enabled
 
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/appservice/enforce_https_traffic_for_webapps/README.md
+++ b/policy_packs/azure/appservice/enforce_https_traffic_for_webapps/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing HTTPS traffic for Azure App Service Web Apps is essential to ensure secure communication between clients and web applications. This measure encrypts data transmitted over the network, protecting it from interception and unauthorized access, thereby enhancing the security and integrity of the web apps and ensuring compliance with security best practices and regulatory standards.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for App Service web apps:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for App Service web apps:
 
 - Enable `HTTPS Only` feature for web apps
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/appservice/enforce_secure_tls_version_for_webapps/README.md
+++ b/policy_packs/azure/appservice/enforce_secure_tls_version_for_webapps/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing a secure TLS version for Azure App Service Web Apps is critical to ensure secure communication between clients and web applications. This measure protects data by using strong encryption protocols, reducing the risk of vulnerabilities associated with older TLS versions, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for App Service web apps:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for App Service web apps:
 
 - Enforce TLS version 1.2 for web apps
 
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/appservice/enforce_webapps_to_not_use_outdated_java_php_python/README.md
+++ b/policy_packs/azure/appservice/enforce_webapps_to_not_use_outdated_java_php_python/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Azure App Service Web Apps to not use outdated Java, PHP, or Python versions is crucial to maintain security and performance. This ensures that applications run on supported, secure versions of these languages, reducing the risk of vulnerabilities, enhancing stability, and ensuring compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for App Service web apps:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for App Service web apps:
 
 - Delete web apps that use outdated Java, PHP or Python versions
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/appservice/enforce_webapps_to_use_managed_service_identity/README.md
+++ b/policy_packs/azure/appservice/enforce_webapps_to_use_managed_service_identity/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Azure App Service Web Apps to use Managed Service Identity (MSI) is essential for enhancing security and simplifying access management. This measure allows web apps to securely access Azure resources without the need for hard-coded credentials, reducing the risk of credential exposure and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for App Service web apps:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for App Service web apps:
 
 - Delete web apps that do not use managed service identity
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section1/README.md
+++ b/policy_packs/azure/cis_v200/section1/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to set identity and access management policies on an Azure Subscription. Identity and Access Management policies are the first step towards a defense-in-depth approach to securing an Azure Cloud Platform environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 1 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 1 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section1/settings)**
 
@@ -72,7 +72,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section2/README.md
+++ b/policy_packs/azure/cis_v200/section2/README.md
@@ -13,7 +13,7 @@ Microsoft Defender products addressed in this section include:
 - Microsoft Defender for IoT
 - Microsoft Defender External Attack Surface Management
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 2 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 2 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section2/settings)**
 
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section3/README.md
+++ b/policy_packs/azure/cis_v200/section3/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to follow to set storage account policies on an Azure Subscription. An Azure storage account provides a unique namespace to store and access Azure Storage data objects.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 3 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 3 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section3/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section4/README.md
+++ b/policy_packs/azure/cis_v200/section4/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to follow to set general database services policies on an Azure Subscription. Subsections will address specific database types.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 4 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 4 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section4/settings)**
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section5/README.md
+++ b/policy_packs/azure/cis_v200/section5/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section contains recommendations for configuring Azure logging and monitoring features.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 5 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 5 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section5/settings)**
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section6/README.md
+++ b/policy_packs/azure/cis_v200/section6/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to follow in order to set networking policies on an Azure subscription.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 6 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 6 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section6/settings)**
 
@@ -72,7 +72,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section7/README.md
+++ b/policy_packs/azure/cis_v200/section7/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to follow for the configuration of Virtual Machines on an Azure subscription.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 7 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 7 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section7/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section8/README.md
+++ b/policy_packs/azure/cis_v200/section8/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to follow for the configuration and use of Azure Key Vault.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 8 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 8 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section8/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cis_v200/section9/README.md
+++ b/policy_packs/azure/cis_v200/section9/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations for Azure App Service.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 9 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of Azure CIS benchmark section 9 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_cis_v200_section9/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/compute/enforce_approved_extensions_are_installed_for_vms/README.md
+++ b/policy_packs/azure/compute/enforce_approved_extensions_are_installed_for_vms/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing that only approved extensions are installed on Azure Compute Virtual Machines is critical for maintaining a secure and controlled environment. This ensures that all installed extensions have been vetted for security and compliance, reducing the risk of vulnerabilities, unauthorized access, and ensuring adherence to organizational policies and security best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute virtual machines:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute virtual machines:
 
 - Stop/Terminate VMs that do not use approved extensions
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/compute/enforce_approved_images_from_trusted_publishers_for_vms/README.md
+++ b/policy_packs/azure/compute/enforce_approved_images_from_trusted_publishers_for_vms/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing Azure compute instances to use approved AMIs from trusted publishers is vital for maintaining a secure and standardized environment. This practice ensures that only trusted, validated images are used, reducing the risk of security vulnerabilities and ensuring compliance with organizational policies and security standards.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute virtual machines:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute virtual machines:
 
 - Stop/Terminate VMs that do not use approved AMIs from trusted publishers
 - Set the image IDs that are approved for use
@@ -77,7 +77,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/compute/enforce_disks_to_be_attached_to_vms/README.md
+++ b/policy_packs/azure/compute/enforce_disks_to_be_attached_to_vms/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing Azure Compute disks to be attached to virtual machines is important for optimizing resource utilization and cost management. This control ensures that all allocated storage is actively used and monitored, reducing the risk of unnecessary expenses and potential security vulnerabilities associated with unattached disks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute disks:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute disks:
 
 - Delete disks that have been unattached for 7 or more days
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/compute/enforce_encryption_at_rest_is_enabled_for_disks/README.md
+++ b/policy_packs/azure/compute/enforce_encryption_at_rest_is_enabled_for_disks/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing encryption at rest for Azure Compute Disks via Disk Encryption Sets is crucial to protect sensitive data stored on virtual machines from unauthorized access and potential breaches. This security measure ensures that data remains confidential and secure, even if the physical storage media is compromised, by using strong encryption algorithms to render the data unreadable without the appropriate decryption keys.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute disks:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute disks:
 
 - Set Disk Encryption Set to be used to encrypt disks
 - Enable Encryption at Rest
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/cosmosdb/enforce_database_accounts_to_be_accessible_to_selected_networks/README.md
+++ b/policy_packs/azure/cosmosdb/enforce_database_accounts_to_be_accessible_to_selected_networks/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Azure Cosmos DB database accounts to be accessible only to selected networks is crucial for enhancing security and controlling access to your data. This measure ensures that only trusted and authorized networks can access the database, reducing the risk of unauthorized access, data breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for CosmosDB database accounts:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for CosmosDB database accounts:
 
 - Set required IP ranges that are allowed to access the database account
 - Set required virtual networks that are allowed to access the database account
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/guardrails/enable_reporting_for_cis_v200/README.md
+++ b/policy_packs/azure/guardrails/enable_reporting_for_cis_v200/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enabling Azure CIS v2.0.0 is essential for ensuring that your Azure environment adheres to industry-recognized security best practices. This provides a robust framework for identifying and mitigating security risks, enhancing compliance with regulatory requirements, and protecting sensitive data by automatically enforcing the security configurations recommended by the CIS benchmarks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable Azure CIS v2.0.0 reporting with and without attestation controls in Guardrails.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable Azure CIS v2.0.0 reporting with and without attestation controls in Guardrails.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_guardrails_enable_reporting_for_cis_v200/settings)**
 
@@ -72,7 +72,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 > [!TIP]
 > You can also update the policy settings in this policy pack directly in the Guardrails console.

--- a/policy_packs/azure/loadbalancer/enforce_load_balancers_to_not_use_unapproved_ports/README.md
+++ b/policy_packs/azure/loadbalancer/enforce_load_balancers_to_not_use_unapproved_ports/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Enforcing that Azure Load Balancers do not use unapproved ports is essential for maintaining a secure network environment. This measure ensures that only approved and necessary ports are used, reducing the risk of unauthorized access and potential attacks, and enhancing overall security and compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for load balancers:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for load balancers:
 
 - Set a list of unapproved ports
 - Delete load balancers that use unapproved ports
@@ -76,7 +76,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/network/enforce_security_groups_to_reject_all_rdp_ssh_inbound_access/README.md
+++ b/policy_packs/azure/network/enforce_security_groups_to_reject_all_rdp_ssh_inbound_access/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing security groups to reject all ingress, RDP, and SSH inbound access is critical for minimizing the attack surface and protecting systems from unauthorized access. This measure ensures that remote administrative access is blocked unless explicitly allowed, reducing the risk of malicious attacks and enhancing overall security posture.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for network security groups:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for network security groups:
 
 - Reject 0.0.0.0/0 ingress traffic
 - Reject inbound access on RDP and SSH ports
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/storage/enforce_containers_block_public_access/README.md
+++ b/policy_packs/azure/storage/enforce_containers_block_public_access/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing Azure Storage Containers to block public access is crucial to prevent unauthorized access and potential data breaches. By ensuring that storage containers are not publicly accessible, organizations can safeguard sensitive data, maintain compliance with security standards, and reduce the risk of exposure to cyber threats.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Storage containers:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Storage containers:
 
 - Enable Private (No anonymous access)
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/azure/storage/enforce_storage_account_blob_containers_block_public_access/README.md
+++ b/policy_packs/azure/storage/enforce_storage_account_blob_containers_block_public_access/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Azure Storage Account Blob Containers to not allow public access is crucial for protecting sensitive data from unauthorized access and potential breaches. By restricting public access, organizations can ensure that only authenticated and authorized users can interact with the stored data, thus enhancing security and compliance with data protection regulations.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for storage accounts:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for storage accounts:
 
 - Enforce block blob public access is set to Enabled
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/bigquery/enforce_datasets_are_not_publicly_accessible/README.md
+++ b/policy_packs/gcp/bigquery/enforce_datasets_are_not_publicly_accessible/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing GCP BigQuery datasets to not be publicly accessible is crucial to protect sensitive and proprietary data from unauthorized access and potential breaches. By restricting public access, organizations can maintain data privacy, comply with regulatory requirements, and safeguard against malicious activities.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for BigQuery datasets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for BigQuery datasets:
 
 - Enforce public access is disabled
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section1/README.md
+++ b/policy_packs/gcp/cis_v200/section1/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers recommendations addressing Identity and Access Management on Google Cloud Platform.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 1 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 1 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section1/settings)**
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section2/README.md
+++ b/policy_packs/gcp/cis_v200/section2/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers recommendations addressing Logging and Monitoring on Google Cloud Platform.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 2 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 2 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section2/settings)**
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section3/README.md
+++ b/policy_packs/gcp/cis_v200/section3/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers recommendations addressing networking on Google Cloud Platform.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 3 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 3 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section3/settings)**
 
@@ -72,7 +72,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section4/README.md
+++ b/policy_packs/gcp/cis_v200/section4/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers recommendations addressing virtual machines on Google Cloud Platform.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 4 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 4 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section4/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section5/README.md
+++ b/policy_packs/gcp/cis_v200/section5/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers recommendations addressing storage on Google Cloud Platform.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 5 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 5 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section5/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section6/README.md
+++ b/policy_packs/gcp/cis_v200/section6/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section covers security recommendations to follow to secure Cloud SQL database services.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 6 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 6 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section6/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/cis_v200/section7/README.md
+++ b/policy_packs/gcp/cis_v200/section7/README.md
@@ -7,7 +7,7 @@ primary_category: "compliance"
 
 This section addresses Google CloudPlatform BigQuery. BigQuery is a serverless, highly-scalable, and cost-effective cloud data warehouse with an in-memory BI Engine and machine learning built in.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 7 best practices.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you automate the enforcement of GCP CIS benchmark section 7 best practices.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_cis_v200_section7/settings)**
 
@@ -71,7 +71,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_block_project_wide_ssh_keys_is_enabled_for_instances/README.md
+++ b/policy_packs/gcp/computeengine/enforce_block_project_wide_ssh_keys_is_enabled_for_instances/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing the enablement of block project-wide SSH keys for GCP Compute Engine instances is important because it restricts the use of universally accessible SSH keys, thereby reducing the risk of unauthorized access. This measure ensures that only instance-specific SSH keys are used, enhancing the security and control over individual instance access.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine instances:
 
 - Enforce project wide SSH keys are blocked
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_disks_to_be_attached_to_instances/README.md
+++ b/policy_packs/gcp/computeengine/enforce_disks_to_be_attached_to_instances/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing GCP Compute Engine disks to be attached to instances is important for optimizing resource utilization and cost management. This control ensures that all allocated storage is actively used and monitored, reducing the risk of unnecessary expenses and potential security vulnerabilities associated with unattached disks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine disks:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine disks:
 
 - Delete disks that have been unattached for 7 or more days
 
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_disks_to_not_be_older_than_7_days/README.md
+++ b/policy_packs/gcp/computeengine/enforce_disks_to_not_be_older_than_7_days/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing GCP Compute Engine Disks to not be older than 7 days is critical to ensure that data storage is continuously refreshed and aligned with the latest security and performance standards. This practice helps prevent the accumulation of outdated and potentially vulnerable disks, thereby enhancing overall data integrity and security.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine disks:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine disks:
 
 - Delete disks that are older than 7 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_be_older_than_7_days/README.md
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_be_older_than_7_days/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing GCP Compute Engine Instances to not be older than 7 days is important to ensure that instances are regularly updated and patched, minimizing the risk of vulnerabilities and security exploits. This practice promotes a secure and resilient infrastructure by ensuring that all instances run the latest software versions and configurations.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine instances:
 
 - Terminate instances that are older than 7 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_external_ip_address/README.md
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_external_ip_address/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing GCP Compute Engine instances to not use external IP addresses is vital for reducing the attack surface and enhancing security. By restricting instances to internal IP addresses, it minimizes exposure to the internet, thereby protecting sensitive data and systems from unauthorized access and potential threats.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine instances:
 
 - Enforce no external IP addresses are used
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_specific_machine_types/README.md
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_specific_machine_types/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing GCP Compute Engine Instances to not use specific machine types is important to ensure compliance with organizational policies and cost management strategies. This control helps prevent the use of machine types that may be unsuitable for certain workloads, excessively costly, or lacking necessary security features, thereby optimizing resource utilization and maintaining a secure environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine instances:
 
 - Set unapproved list if instance sizes
 - Set unapproved list of instance family
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/README.md
+++ b/policy_packs/gcp/computeengine/enforce_instances_to_not_use_unapproved_images/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing GCP Compute Engine instances to not use unapproved images is crucial for maintaining security, compliance, and consistency across the infrastructure. It ensures that all instances adhere to organizational standards, reducing the risk of vulnerabilities, unauthorized software, and potential breaches.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Compute Engine instances:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Compute Engine instances:
 
 - Set list of approved image IDs
 - Stop/Terminate instances that use unapproved images
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/guardrails/enable_event_handlers/README.md
+++ b/policy_packs/gcp/guardrails/enable_event_handlers/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 The Guardrails Event Handlers are responsible for conveying events from GCP Logging back to Guardrails for processing. This is a requirement for Guardrails to process and respond in real-time.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable regional [Event Handlers](https://turbot.com/guardrails/docs/integrations/gcp/real-time-events) for GCP Projects in Guardrails.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable regional [Event Handlers](https://turbot.com/guardrails/docs/integrations/gcp/real-time-events) for GCP Projects in Guardrails.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_guardrails_enable_event_handlers/settings)**
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/guardrails/enable_event_poller/README.md
+++ b/policy_packs/gcp/guardrails/enable_event_poller/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 The Guardrails Event Poller are responsible polling GCP Logging at intervals specified and retrieves the latest events for processing.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for GCP Projects in Guardrails:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GCP Projects in Guardrails:
 
 - Set a polling interval, i.e. the frequency to poll events from GCP
 - Set a polling interval window
@@ -75,4 +75,4 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).

--- a/policy_packs/gcp/guardrails/enable_reporting_for_cis_v200/README.md
+++ b/policy_packs/gcp/guardrails/enable_reporting_for_cis_v200/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enabling GCP CIS v2.0.0 is essential for ensuring that your GCP environment adheres to industry-recognized security best practices. This provides a robust framework for identifying and mitigating security risks, enhancing compliance with regulatory requirements, and protecting sensitive data by automatically enforcing the security configurations recommended by the CIS benchmarks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you enable GCP CIS v2.0.0 reporting with and without attestation controls in Guardrails.
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable GCP CIS v2.0.0 reporting with and without attestation controls in Guardrails.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_guardrails_enable_reporting_for_cis_v200/settings)**
 
@@ -72,7 +72,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 > [!TIP]
 > You can also update the policy settings in this policy pack directly in the Guardrails console.

--- a/policy_packs/gcp/iam/enforce_trusted_domains_to_access_project_iam_policy/README.md
+++ b/policy_packs/gcp/iam/enforce_trusted_domains_to_access_project_iam_policy/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing trusted domains to access GCP IAM project policies is essential for ensuring that only authorized and verified domains can interact with your project's IAM policies. This measure helps prevent unauthorized access, enhances security by limiting access to trusted entities, and ensures compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for project policy:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for project policy:
 
 - Set a list of trusted domains
 - Revoke untrusted access from project IAM policy
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/iam/enforce_user_service_account_keys_are_rotated_in_90_days/README.md
+++ b/policy_packs/gcp/iam/enforce_user_service_account_keys_are_rotated_in_90_days/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing that GCP IAM user-managed service account keys are rotated every 90 days is crucial for maintaining security and reducing the risk of key compromise. Regular key rotation ensures that any potentially exposed or compromised keys are rendered obsolete, thereby protecting access to GCP resources and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM user-managed service account keys:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM user-managed service account keys:
 
 - Delete service account keys that are older than 90 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/iam/enforce_user_service_accounts_belong_to_trusted_domains_and_users/README.md
+++ b/policy_packs/gcp/iam/enforce_user_service_accounts_belong_to_trusted_domains_and_users/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing GCP IAM User-Managed Service Accounts to belong to trusted domains and users is essential to ensure that only verified and authorized entities can access and manage cloud resources. This control mitigates the risk of unauthorized access, data breaches, and malicious activities by ensuring that service accounts are managed within a secure and trusted environment.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM user-managed service accounts:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM user-managed service accounts:
 
 - Set a list of trusted domains
 - Set a list of trusted users
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/iam/enforce_user_service_accounts_to_not_have_admin_privileges/README.md
+++ b/policy_packs/gcp/iam/enforce_user_service_accounts_to_not_have_admin_privileges/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing that GCP IAM user-managed service accounts do not have admin privileges is essential for maintaining the principle of least privilege. This minimizes the risk of unauthorized access and potential misuse of administrative capabilities, enhancing security by ensuring that service accounts only have the permissions necessary to perform their specific tasks.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for IAM user-managed service accounts:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM user-managed service accounts:
 
 - Delete service accounts that have `roles/owner`, `roles/admin` or `roles/editor` privileges
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/iam/enforce_users_belong_to_approved_domains/README.md
+++ b/policy_packs/gcp/iam/enforce_users_belong_to_approved_domains/README.md
@@ -7,7 +7,7 @@ primary_category: "access management"
 
 Enforcing that GCP IAM users belong to approved domains is crucial for maintaining a secure and controlled environment. This measure ensures that only users from trusted and verified domains can access your GCP resources, reducing the risk of unauthorized access and enhancing overall security and compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for GCP IAM users:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GCP IAM users:
 
 - Set a list of approved domains
 - Delete users that do not belong to the approved domains
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/kms/check_crypto_keys_are_rotated_regularly/README.md
+++ b/policy_packs/gcp/kms/check_crypto_keys_are_rotated_regularly/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 KMS Crypto Keys should be rotated on regular basis. A rotation schedule defines the frequency of rotation, and optionally the date and time when the first rotation occurs. The rotation schedule can be based on either the key's age or the number or volume of messages encrypted with a key version. Enforcing regular rotation of GCP KMS crypto keys is essential for maintaining the security and integrity of encrypted data. Regular key rotation mitigates the risk of key compromise, ensuring that even if a key is exposed, its usage window is limited, thereby enhancing overall security and ensuring compliance with best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for KMS crypto keys:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for KMS crypto keys:
 
 - Check and alarm if crypto keys have rotation period of more than 90 days
 
@@ -73,4 +73,4 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).

--- a/policy_packs/gcp/kms/enforce_crypto_keys_are_not_publicly_accessible/README.md
+++ b/policy_packs/gcp/kms/enforce_crypto_keys_are_not_publicly_accessible/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing that GCP KMS crypto keys are not publicly accessible is vital for protecting sensitive data from unauthorized access. This ensures that cryptographic keys, which are essential for data encryption and security, are only accessible to authorized users and services, thereby preventing potential data breaches and maintaining compliance with security best practices and regulatory standards.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for KMS crypto keys:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for KMS crypto keys:
 
 - Remove access for non-trusted members
 - Do not allow `allUsers` access to crypto keys
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/kubernetesengine/enforce_encryption_for_secrets_is_enabled_for_clusters/README.md
+++ b/policy_packs/gcp/kubernetesengine/enforce_encryption_for_secrets_is_enabled_for_clusters/README.md
@@ -8,7 +8,7 @@ type: "featured"
 
 Enforcing encryption for secrets in GCP GKE clusters is critical for protecting sensitive information stored within the cluster. This measure ensures that secrets, such as passwords and API keys, are encrypted, safeguarding them from unauthorized access and potential breaches, and ensuring compliance with security best practices and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for GKE clusters:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for GKE clusters:
 
 - Delete clusters that do not have database encryption state set to `ENCRYPTED`
 
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/network/check_https_is_enforced_for_load_balancers/README.md
+++ b/policy_packs/gcp/network/check_https_is_enforced_for_load_balancers/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Ensure that GCP Network Load Balancers are configured to use valid SSL/TLS certificates in order to handle encrypted web traffic. SSL certificate resources contain SSL certificate information that the load balancer uses to terminate SSL/TLS when HTTPS clients connect to it. This practice guarantees that data transmitted between clients and load-balanced applications is encrypted, protecting it from interception and unauthorized access, thereby enhancing security and compliance with regulatory requirements and best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for network load balancers:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for network load balancers:
 
 - Check and alarm if the URL map for load balancers is configured to use target https proxy
 
@@ -73,4 +73,4 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).

--- a/policy_packs/gcp/network/enforce_default_vpc_network_is_not_used_for_projects/README.md
+++ b/policy_packs/gcp/network/enforce_default_vpc_network_is_not_used_for_projects/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Enforcing that the default VPC network is not used within GCP projects is essential for maintaining a secure and customized network environment. This practice encourages the creation of tailored VPC networks with specific configurations and security controls, reducing the risk of misconfigurations and enhancing overall network security and compliance with best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for VPC networks:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for VPC networks:
 
 - Remove default networks that are used within projects
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/network/enforce_firewall_rules_with_port_ranges_to_not_allow_incoming_traffic/README.md
+++ b/policy_packs/gcp/network/enforce_firewall_rules_with_port_ranges_to_not_allow_incoming_traffic/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Ensure that your Google Cloud VPC network firewall rules don't have range of ports configured to allow inbound traffic, in order to protect associated virtual machine instances against Denial-of-Service (DoS) attacks or brute-force attacks. To follow cloud security best practices, it is strongly recommended to open only specific ports within your firewall rules, based on your application requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Network firewalls:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Network firewalls:
 
 - Revoke firewall rules that allow incoming traffic from all IP addresses
 - Revoke firewall rules that have port range size of greater than 1
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/network/enforce_firewall_to_not_allow_egress_access/README.md
+++ b/policy_packs/gcp/network/enforce_firewall_to_not_allow_egress_access/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Enforcing GCP network firewalls to not allow any egress access is essential for maintaining a highly secure environment. This measure ensures that no outbound traffic is permitted, preventing data exfiltration and unauthorized communication with external systems, thereby reducing the risk of data breaches and ensuring compliance with strict security policies and regulatory requirements.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for network load balancers:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for network load balancers:
 
 - Delete firewall network that contain egress allowed rules
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/network/enforce_logging_is_enabled_for_firewalls/README.md
+++ b/policy_packs/gcp/network/enforce_logging_is_enabled_for_firewalls/README.md
@@ -7,7 +7,7 @@ primary_category: "logging"
 
 Enforcing GCP VPC Network Firewall Logging is essential for maintaining comprehensive visibility and auditing capabilities of network traffic. This control helps detect and investigate security incidents, monitor policy compliance, and ensure timely response to potential threats by capturing detailed logs of all firewall activity.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Network firewalls:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Network firewalls:
 
 - Enable logging
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/orgpolicy/check_default_vpc_creation_is_disabled_for_projects/README.md
+++ b/policy_packs/gcp/orgpolicy/check_default_vpc_creation_is_disabled_for_projects/README.md
@@ -7,7 +7,7 @@ primary_category: "networking"
 
 Checking if the creation of the default VPC network is disabled at the GCP project level is important for enforcing a secure and customized network architecture. This practice ensures that all projects within the organization use purpose-built VPC networks with specific configurations and security controls, reducing the risk of misconfigurations and enhancing overall network security and compliance with best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for org policies:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for org policies:
 
 - Checks if the project org policy `Skip default network creation` the creation of default network is set to `On`
 
@@ -73,4 +73,4 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).

--- a/policy_packs/gcp/storage/enforce_buckets_are_not_publicly_accessible/README.md
+++ b/policy_packs/gcp/storage/enforce_buckets_are_not_publicly_accessible/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Cloud Storage buckets, like other GCP resources, have Cloud Identity and Access Management (IAM) policies configured to determine who can have access to the storage resources. To deny access from anonymous and public users, remove the bindings for "allUsers" and "allAuthenticatedUsers" members from the storage bucket's IAM policy. The "allUsers" is a special member identifier that represents any user on the Internet, including authenticated and unauthenticated users, while the "allAuthenticatedUsers" is an identifier that represents any user or service account that can sign in to Google Cloud Platform (GCP) with a Google account.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for storage buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for storage buckets:
 
 - Remove access for non-trusted members
 - Do not allow `allUsers` access to buckets
@@ -75,7 +75,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/storage/enforce_buckets_to_not_be_older_than_7_days/README.md
+++ b/policy_packs/gcp/storage/enforce_buckets_to_not_be_older_than_7_days/README.md
@@ -7,7 +7,7 @@ primary_category: "cost controls"
 
 Enforcing that GCP storage buckets are not older than 7 days is crucial for maintaining an up-to-date and secure storage environment. This practice ensures that only recently created buckets are in use, reducing the risk of using outdated configurations and improving data security and compliance with best practices.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Storage buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Storage buckets:
 
 - Delete buckets that are older than 7 days
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/storage/enforce_creator_and_creationtime_labels_for_buckets/README.md
+++ b/policy_packs/gcp/storage/enforce_creator_and_creationtime_labels_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "tagging"
 
 Enforcing Creator and Creation Time labels for GCP Storage Buckets is important for effective tracking and auditing of data assets. These labels provide critical metadata that helps in identifying the origin and creation time of storage buckets, enhancing accountability and facilitating compliance with data governance policies.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Storage buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Storage buckets:
 
 - Enforce `creator` and `creationTime` tags
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/storage/enforce_encryption_at_rest_is_enabled_for_buckets/README.md
+++ b/policy_packs/gcp/storage/enforce_encryption_at_rest_is_enabled_for_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "security"
 
 Enforcing Encryption at Rest for GCP Storage Buckets is essential to protect sensitive data from unauthorized access and potential breaches by ensuring that all data is automatically encrypted before being stored. This measure safeguards data confidentiality and integrity, even if physical security measures are compromised.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Storage buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Storage buckets:
 
 - Set a KMS symmetric crypto key to be used for encryption
 - Enable Encryption at Rest for buckets via Google managed key or KMS crypto key
@@ -74,7 +74,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 

--- a/policy_packs/gcp/storage/enforce_uniform_access_on_buckets/README.md
+++ b/policy_packs/gcp/storage/enforce_uniform_access_on_buckets/README.md
@@ -7,7 +7,7 @@ primary_category: "data protection"
 
 Enforcing Uniform Access for GCP Storage Buckets is crucial to ensure consistent and centralized management of access permissions, reducing the risk of unauthorized access and potential data breaches. This control helps streamline the administration of security policies, ensuring all objects within a bucket inherit the same access controls, thus maintaining data integrity and security.
 
-This [policy pack](https://turbot.com/guardrails/docs/concepts/resources/policy-packs) can help you configure the following settings for Storage buckets:
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Storage buckets:
 
 - Set uniform access
 
@@ -73,7 +73,7 @@ Log into your Guardrails workspace and [attach the policy pack to a resource](ht
 
 If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
 
-For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/resources/policy-packs).
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
 
 ### Enable Enforcement
 


### PR DESCRIPTION
Policy Pack documentation link in Policy Pack README files pointed to `https://turbot.com/guardrails/docs/concepts/resources/policy-packs`. It should point to `https://turbot.com/guardrails/docs/concepts/policy-packs` instead.
