### PR TITLE
Policy Pack for backing up EBS volumes using AWS Backup.

### DIFF
--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -11,7 +11,6 @@ This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can
 - Create the required IAM role for AWS Backup to use.
 - Create Backup Vaults, Backup Plans and Backup Selections. 
 
-
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_backup_enforce_ebs_volume_backups/settings)**
 
 ## Getting Started

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -9,7 +9,7 @@ Enforcing backups of EBS volumes provides a crucial defense against lost data. G
 
 This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for AWS Backup: 
 - Create the required IAM role for AWS Backup to use.
-- Create Backup Vaults, Backup Plans and Backup Selections. 
+- Create Backup vaults, plans, and selections to backup EBS volumes.
 
 **[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_backup_enforce_ebs_volume_backups/settings)**
 

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -113,7 +113,8 @@ terraform apply
 ```
 
 ## Disable Backups
-- To stop backups from happening while preserving the existing backups, remove this resource definition from the `AWS > Backup > Stack > Source` policy setting. With no resource
+
+To stop backups from happening while preserving the existing backups, remove this resource definition from the `AWS > Backup > Stack > Source` policy setting:
 ```hcl
     resource "aws_backup_selection" "ebs_resource_assignment" {
       iam_role_arn = "arn:aws:iam::{{ $.account.id }}:role/turbot/core/guardrails_backup_service_role"

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -1,0 +1,160 @@
+---
+categories: ["data protection"]
+primary_category: "data protection"
+---
+
+# Enforce Backups of EBS Volumes
+
+Enforcing backups of EBS volumes provides a crucial defense against lost data. Guardrails uses the AWS Backup service to create and manage backups of EBS volumes. 
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings to create the required Backup IAM role, Backup Vaults, Backup Plans and Backup Selections. 
+
+- Stop/Terminate replication instances which have public access enabled
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_dms_enforce_replication_instances_to_not_be_publicly_accessible/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- The following Guardrails mods need to be installed:
+  - [@turbot/aws](https://hub.guardrails.turbot.com/mods/aws/mods/aws)
+  - [@turbot/aws-iam](https://hub.guardrails.turbot.com/mods/aws/mods/aws-iam)
+  - [@turbot/aws-backup](https://hub.guardrails.turbot.com/mods/aws/mods/aws-backup)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/backup/enforce_ebs_volume_backups
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_dms_replication_instance_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-dms#/policy/types/replicationInstanceApproved"
+  # value    = "Check: Approved"
+  value    = "Enforce: Stop unapproved"
+  # value    = "Enforce: Stop unapproved if new"
+  # value    = "Enforce: Delete unapproved if new"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```
+
+## Decommission the Backups.
+1. Edit the Backup > Stack > Source policy setting in the policy pack.
+   1. **Flush Backups**: To flush the current backups, set the retention period to one day, as shown below. 
+  2. **Prevent new backups**: Remove the Backup Selection from the `AWS > Backup > Stack > Source`.  This will prevent new backups from happening.
+
+When the changes are complete the `template` attribute for `Backup > Stack > Source` should look like this. 
+```hcl
+    |
+    resource "aws_backup_vault" "vault" {
+      name = "guardrails-backup-vault"
+      tags = {
+        turbot_version = "v5"
+      }
+    }
+    resource "aws_backup_plan" "guardrails_ebs_backups" {
+      name = "guardrails-backup-plan"
+      rule {
+        # The time allowed for the job to start, any longer and it will be cancelled.
+        start_window = 480
+        # The amount of time allowed for the backup to complete, before it is cancelled.
+        completion_window = 10080
+        #
+        rule_name         = "guardrails-ebs-backups-rule"
+        schedule          = "cron(0 5 ? * * *)"
+        target_vault_name = aws_backup_vault.vault.name
+        lifecycle {
+          delete_after = 1
+        }
+      }
+    }
+```
+
+2. **Apply the policy pack changes**: Wait a day or two for the backups to be flushed from the Guardrails Backup vault.  AWS will not allow a vault to be destroyed when backups are still present. 
+3. **Decommission the Backup Vault**: This is most easily done by replacing `template` and `template_input` attributes of `Backup > Stack > Source` as shown below. The `[]` value instructs the `Backup > Stack` control to destroy all managed resources. Apply the changes to the Policy Pack.
+```hcl
+# AWS > Backup > Stack > Source
+resource "turbot_policy_setting" "aws_backup_stack_source" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-backup#/policy/types/backupStackSource"
+  value    = "[]"  
+}
+```
+4. **Verify Vault Decommission**: Verify that all the `Backup > Stack` controls have gone into an `ok` state.  If they go into `error`, the `Backup > Stack` control logs should give a good indication of what's wrong.
+5. **Remove Backup IAM Role**: Set the `AWS > IAM > Stack > Source` policy to the below Terraform:  This will remove the Backup IAM role.
+```hcl
+# AWS > IAM > Stack > Source
+resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-iam#/policy/types/iamStackSource"
+  value    = "[]"
+}
+```
+6. **Verify IAM Role Decommission**: Verify that all the `IAM > Stack` controls are in `ok`.
+7. **Remove Policy Pack**: Remove the policy pack from your Guardrails workspace. 

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -122,7 +122,11 @@ To stop backups from happening while preserving the existing backups, remove thi
       resources = ["arn:aws:ec2:*:*:volume/*"]
     }
 ```
-- Commit the updated policy setting via Terraform then let the `AWS > Backup > Stack` make the changes. 
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
 
 
 ## Decommission the Backup Vault

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -127,12 +127,13 @@ Then re-apply the changes:
 ```sh
 terraform plan
 terraform apply
-
+````
 
 ## Decommission the Backup Vault
-To completely remove a Backup Vault and all backups, execute the following steps:
+To completely remove a Backup Vault and all backups, execute the following steps.
 
-- Edit the Backup > Stack > Source policy setting in the policy pack.
+### Delete EBS Volume Backups
+ Edit the Backup > Stack > Source policy setting in the policy pack.
   - To flush the current backups, set the retention period to one day, as shown below. 
   - Remove the Backup Selection from the `AWS > Backup > Stack > Source`.  This will prevent new backups from happening.
 
@@ -163,8 +164,16 @@ When the changes are complete the `template` attribute for `Backup > Stack > Sou
     }
 ```
 
-- Wait a day or two for the backups to be flushed from the Guardrails Backup vault.  AWS will not allow a vault to be destroyed when backups are still present. 
-- This is most easily done by replacing `template` and `template_input` attributes of `Backup > Stack > Source` as shown below. The `[]` value instructs the `Backup > Stack` control to destroy all managed resources. Apply the changes to the Policy Pack.
+Apply the changes:
+
+```sh
+terraform plan
+terraform apply
+````
+
+### Delete Backup Vault
+Wait a day or two for the backups to be flushed from the Guardrails Backup vault.  AWS will not allow a vault to be destroyed when backups are still present. 
+This is most easily done by replacing `template` and `template_input` attributes of `Backup > Stack > Source` as shown below. The `[]` value instructs the `Backup > Stack` control to destroy all managed resources. Apply the changes to the Policy Pack.
 ```hcl
 # AWS > Backup > Stack > Source
 resource "turbot_policy_setting" "aws_backup_stack_source" {
@@ -173,8 +182,16 @@ resource "turbot_policy_setting" "aws_backup_stack_source" {
   value    = "[]"  
 }
 ```
-- Verify that all the `Backup > Stack` controls have gone into an `ok` state.  If they go into `error`, the `Backup > Stack` control logs should give a good indication of what's wrong.
-- Set the `AWS > IAM > Stack > Source` policy to the below Terraform:  This will remove the Backup IAM role.
+Apply the changes:
+
+```sh
+terraform plan
+terraform apply
+````
+Verify that all the `Backup > Stack` controls have gone into an `ok` state.  If they go into `error`, the `Backup > Stack` control logs should give a good indication of what's wrong.
+
+### Delete Backup IAM Role
+Set the `AWS > IAM > Stack > Source` policy to the below Terraform:  This will remove the Backup IAM role.
 ```hcl
 # AWS > IAM > Stack > Source
 resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
@@ -183,5 +200,12 @@ resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
   value    = "[]"
 }
 ```
-- Verify that all the `IAM > Stack` controls are in `ok`.
-- Remove the policy pack from your Guardrails workspace. 
+Re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+````
+ 
+Verify that all the `IAM > Stack` controls are in `ok`.  Resolve any controls in an `error` state. 
+Remove the policy pack from your Guardrails workspace using `terraform destroy`. 

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/README.md
@@ -114,6 +114,7 @@ terraform apply
 ## Disable Backups
 
 To stop backups from happening while preserving the existing backups, remove this resource definition from the `AWS > Backup > Stack > Source` policy setting:
+
 ```hcl
     resource "aws_backup_selection" "ebs_resource_assignment" {
       iam_role_arn = "arn:aws:iam::{{ $.account.id }}:role/turbot/core/guardrails_backup_service_role"
@@ -122,7 +123,8 @@ To stop backups from happening while preserving the existing backups, remove thi
       resources = ["arn:aws:ec2:*:*:volume/*"]
     }
 ```
-Then re-apply the changes:
+
+Then apply the changes:
 
 ```sh
 terraform plan
@@ -130,14 +132,17 @@ terraform apply
 ````
 
 ## Decommission the Backup Vault
+
 To completely remove a Backup Vault and all backups, execute the following steps.
 
 ### Delete EBS Volume Backups
- Edit the Backup > Stack > Source policy setting in the policy pack.
+
+Edit the `Backup > Stack > Source` policy setting in the policy pack.
   - To flush the current backups, set the retention period to one day, as shown below. 
   - Remove the Backup Selection from the `AWS > Backup > Stack > Source`.  This will prevent new backups from happening.
 
-When the changes are complete the `template` attribute for `Backup > Stack > Source` should look like this. 
+When the changes are complete the `template` attribute for `Backup > Stack > Source` should look like this:
+ 
 ```hcl
     |
     resource "aws_backup_vault" "vault" {
@@ -164,7 +169,7 @@ When the changes are complete the `template` attribute for `Backup > Stack > Sou
     }
 ```
 
-Apply the changes:
+Then apply the changes:
 
 ```sh
 terraform plan
@@ -172,8 +177,11 @@ terraform apply
 ````
 
 ### Delete Backup Vault
-Wait a day or two for the backups to be flushed from the Guardrails Backup vault.  AWS will not allow a vault to be destroyed when backups are still present. 
-This is most easily done by replacing `template` and `template_input` attributes of `Backup > Stack > Source` as shown below. The `[]` value instructs the `Backup > Stack` control to destroy all managed resources. Apply the changes to the Policy Pack.
+
+Wait a day or two for the backups to be flushed from the Guardrails Backup vault. AWS will not allow a vault to be destroyed when backups are still present.
+
+This is most easily done by replacing `template` and `template_input` attributes of `Backup > Stack > Source` as shown below. The `[]` value instructs the `Backup > Stack` control to destroy all managed resources.
+
 ```hcl
 # AWS > Backup > Stack > Source
 resource "turbot_policy_setting" "aws_backup_stack_source" {
@@ -182,16 +190,20 @@ resource "turbot_policy_setting" "aws_backup_stack_source" {
   value    = "[]"  
 }
 ```
-Apply the changes:
+
+Then apply the changes:
 
 ```sh
 terraform plan
 terraform apply
 ````
+
 Verify that all the `Backup > Stack` controls have gone into an `ok` state.  If they go into `error`, the `Backup > Stack` control logs should give a good indication of what's wrong.
 
 ### Delete Backup IAM Role
-Set the `AWS > IAM > Stack > Source` policy to the below Terraform:  This will remove the Backup IAM role.
+
+Edit the `AWS > IAM > Stack > Source` policy to the following:
+
 ```hcl
 # AWS > IAM > Stack > Source
 resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
@@ -200,12 +212,18 @@ resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
   value    = "[]"
 }
 ```
-Re-apply the changes:
+
+Then apply the changes:
 
 ```sh
 terraform plan
 terraform apply
 ````
  
-Verify that all the `IAM > Stack` controls are in `ok`.  Resolve any controls in an `error` state. 
-Remove the policy pack from your Guardrails workspace using `terraform destroy`. 
+Verify that all the `IAM > Stack` controls are in `ok`.  Resolve any controls in an `error` state.
+
+Finally, remove the policy pack from your Guardrails workspace:
+
+```sh
+terraform destroy
+```

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/main.tf
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce EBS Volume Backups"
+  description = "Mitigate the risk of lost data by using the AWS Backup service to make backups of EBS volumes"
+  akas        = ["aws_backup_enforce_ebs_volume_backups"]
+}

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/policies.tf
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/policies.tf
@@ -1,16 +1,15 @@
 # AWS > Backup > Stack
 resource "turbot_policy_setting" "aws_backup_stack" {
   resource = turbot_policy_pack.main.id
-  type = "tmod:@turbot/aws-backup#/policy/types/backupStack"
-  #   value    = "Check: Configured"
-  value    = "Enforce: Configured"
+  type     = "tmod:@turbot/aws-backup#/policy/types/backupStack"
+  value    = "Check: Configured"
+  # value    = "Enforce: Configured"
 }
 
 # AWS > Backup > Stack > Source
 resource "turbot_policy_setting" "aws_backup_stack_source" {
   resource       = turbot_policy_pack.main.id
   type           = "tmod:@turbot/aws-backup#/policy/types/backupStackSource"
-  # value          = "[]"  # To decommission the backup vault, uncomment this line and comment out the template and template_input.
   template_input = <<-EOT
     {
       account {
@@ -46,9 +45,10 @@ resource "turbot_policy_setting" "aws_backup_stack_source" {
       iam_role_arn = "arn:aws:iam::{{ $.account.id }}:role/turbot/core/guardrails_backup_service_role"
       name         = "guardrails-ebs-resource-assignment"
       plan_id      = aws_backup_plan.guardrails_ebs_backups.id
-      resources = ["arn:aws:ec2:*:*:volume/*"]
+      resources    = ["arn:aws:ec2:*:*:volume/*"]
     }
   EOT
+  # value          = "[]"  # To decommission the backup vault, uncomment this line and comment out the template and template_input.
 }
 
 # AWS > Backup > Stack > Terraform Version
@@ -62,57 +62,58 @@ resource "turbot_policy_setting" "aws_backup_backup_stack_terraform_version" {
 # AWS > IAM > Stack > Source
 resource "turbot_policy_setting" "aws_iam_iam_stack" {
   resource = turbot_policy_pack.main.id
-  type = "tmod:@turbot/aws-iam#/policy/types/iamStack"
-  #   value    = "Check: Configured"
-  value    = "Enforce: Configured"
+  type     = "tmod:@turbot/aws-iam#/policy/types/iamStack"
+  value    = "Check: Configured"
+  # value    = "Enforce: Configured"
 }
 
 # AWS > IAM > Stack > Source
 resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
-  resource = turbot_policy_pack.main.id
-  type     = "tmod:@turbot/aws-iam#/policy/types/iamStackSource"
-  # value = "[]"  # To decommission the iam role, uncomment this line and comment out the template and template_input.
-  template_input = <<EOT
-  {
-    account {
-      metadata
-    }
-  }
-EOT
-  template       = <<EOT
-|
-resource "aws_iam_role" "guardrails_backup_service_role" {
-  name = "guardrails_backup_service_role"
-  path = "/turbot/core/"
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
-    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
-  ]
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/aws-iam#/policy/types/iamStackSource"
+  template_input = <<-EOT
     {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": ["backup.amazonaws.com"]
-      },
-      "Action": "sts:AssumeRole"
+      account {
+        metadata
+      }
     }
-  ]
-}
-EOF
-  tags = {
-    turbot_version = "v5"
-  }
-  lifecycle {
-    ignore_changes = [tags]
-  }
-}
-EOT
+  EOT
+  template       = <<-EOT
+    |
+    resource "aws_iam_role" "guardrails_backup_service_role" {
+      name = "guardrails_backup_service_role"
+      path = "/turbot/core/"
+      managed_policy_arns = [
+        "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+        "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+      ]
+      assume_role_policy = <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": ["backup.amazonaws.com"]
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+    EOF
+      tags = {
+        turbot_version = "v5"
+      }
+      lifecycle {
+        ignore_changes = [tags]
+      }
+    }
+    EOT
+  # value = "[]"  # To decommission the iam role, uncomment this line and comment out the template and template_input.
 }
 
+# AWS > IAM > Stack > Source > Terraform Version
 resource "turbot_policy_setting" "aws_iam_iam_stack_terraform_version" {
   resource = turbot_policy_pack.main.id
   type     = "tmod:@turbot/aws-iam#/policy/types/iamStackTerraformVersion"

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/policies.tf
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/policies.tf
@@ -13,7 +13,7 @@ resource "turbot_policy_setting" "aws_backup_stack_source" {
   template_input = <<-EOT
     {
       account {
-        id: Id
+        id: get(path: "Id")
       }
     }
   EOT

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/policies.tf
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/policies.tf
@@ -1,0 +1,120 @@
+# AWS > Backup > Stack
+resource "turbot_policy_setting" "aws_backup_stack" {
+  resource = turbot_policy_pack.main.id
+  type = "tmod:@turbot/aws-backup#/policy/types/backupStack"
+  #   value    = "Check: Configured"
+  value    = "Enforce: Configured"
+}
+
+# AWS > Backup > Stack > Source
+resource "turbot_policy_setting" "aws_backup_stack_source" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/aws-backup#/policy/types/backupStackSource"
+  # value          = "[]"  # To decommission the backup vault, uncomment this line and comment out the template and template_input.
+  template_input = <<-EOT
+    {
+      account {
+        id: Id
+      }
+    }
+  EOT
+  template       = <<-EOT
+    |
+    resource "aws_backup_vault" "vault" {
+      name = "guardrails-backup-vault"
+      tags = {
+        turbot_version = "v5"
+      }
+    }
+    resource "aws_backup_plan" "guardrails_ebs_backups" {
+      name = "guardrails-backup-plan"
+      rule {
+        # The time allowed for the job to start, any longer and it will be cancelled.
+        start_window = 480
+        # The amount of time allowed for the backup to complete, before it is cancelled.
+        completion_window = 10080
+        #
+        rule_name         = "guardrails-ebs-backups-rule"
+        schedule          = "cron(0 5 ? * * *)"
+        target_vault_name = aws_backup_vault.vault.name
+        lifecycle {
+          delete_after = 1
+        }
+      }
+    }
+    resource "aws_backup_selection" "ebs_resource_assignment" {
+      iam_role_arn = "arn:aws:iam::{{ $.account.id }}:role/turbot/core/guardrails_backup_service_role"
+      name         = "guardrails-ebs-resource-assignment"
+      plan_id      = aws_backup_plan.guardrails_ebs_backups.id
+      resources = ["arn:aws:ec2:*:*:volume/*"]
+    }
+  EOT
+}
+
+# AWS > Backup > Stack > Terraform Version
+resource "turbot_policy_setting" "aws_backup_backup_stack_terraform_version" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-backup#/policy/types/backupStackTerraformVersion"
+  value    = "0.15.*"
+}
+
+
+# AWS > IAM > Stack > Source
+resource "turbot_policy_setting" "aws_iam_iam_stack" {
+  resource = turbot_policy_pack.main.id
+  type = "tmod:@turbot/aws-iam#/policy/types/iamStack"
+  #   value    = "Check: Configured"
+  value    = "Enforce: Configured"
+}
+
+# AWS > IAM > Stack > Source
+resource "turbot_policy_setting" "aws_iam_iam_stack_source" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-iam#/policy/types/iamStackSource"
+  # value = "[]"  # To decommission the iam role, uncomment this line and comment out the template and template_input.
+  template_input = <<EOT
+  {
+    account {
+      metadata
+    }
+  }
+EOT
+  template       = <<EOT
+|
+resource "aws_iam_role" "guardrails_backup_service_role" {
+  name = "guardrails_backup_service_role"
+  path = "/turbot/core/"
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+  ]
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": ["backup.amazonaws.com"]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+  tags = {
+    turbot_version = "v5"
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+EOT
+}
+
+resource "turbot_policy_setting" "aws_iam_iam_stack_terraform_version" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-iam#/policy/types/iamStackTerraformVersion"
+  value    = "0.15.*"
+}

--- a/policy_packs/aws/backup/enforce_ebs_volume_backups/providers.tf
+++ b/policy_packs/aws/backup/enforce_ebs_volume_backups/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
- Creates the required IAM role.
- Creates the backup vault, backup selection and backup plan.
- README describes how to roll out and decommission.