### PR TITLE
Restore Guardails Default Security Groups

### DIFF
--- a/enterprise_installation/guardrails_security_groups.yml
+++ b/enterprise_installation/guardrails_security_groups.yml
@@ -1,0 +1,100 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Turbot required AWS Security groups for TEF 1.6.0+
+
+Parameters:
+  TurbotVpc:
+    Description: VPC where Turbot is installed into.
+    Type: "AWS::EC2::VPC::Id"
+
+Resources:
+  OutboundInternetSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: turbot_outbound_internet_security_group
+      GroupDescription: Allow outbound HTTPS to the Internet.
+      VpcId: !Ref TurbotVpc
+      SecurityGroupEgress:
+        - Description: Outbound HTTPS Internet access
+          CidrIp: 0.0.0.0/0
+          FromPort: 443
+          ToPort: 443
+          IpProtocol: tcp
+          #
+          # Without opening port 80, ECS optimised image will timeout:
+          # Could not retrieve mirrorlist http://repo.ap-southeast-2.amazonaws.com/latest/main/mirror.list error was
+          # 12: Timeout on http://repo.ap-southeast-2.amazonaws.com/latest/main/mirror.list: (28, 'Connection timed out
+          # after 5000 milliseconds') Mar 05 00:12:33 cloud-init[2231]: util.py[WARNING]: Package upgrade failed
+          #
+          # The instance still boots OK but it's adding extra initialisation time
+          #
+        - Description: Outbound HTTP Internet access. Needed by cloud-init in ECS optimised image
+          CidrIp: 0.0.0.0/0
+          FromPort: 80
+          ToPort: 80
+          IpProtocol: tcp
+        - Description: Outbound TCP DNS access.
+          CidrIp: 0.0.0.0/0
+          FromPort: 53
+          ToPort: 53
+          IpProtocol: tcp
+        - Description: Outbound UDP DNS Access.
+          CidrIp: 0.0.0.0/0
+          FromPort: 53
+          ToPort: 53
+          IpProtocol: udp
+        - Description: Outbound NTP access.
+          CidrIp: 0.0.0.0/0
+          FromPort: 123
+          ToPort: 123
+          IpProtocol: tcp
+
+  LoadBalancerSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupName: turbot_load_balancer_security_group
+      GroupDescription: Load Balancer
+      VpcId: !Ref TurbotVpc
+
+  ApiServiceSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupName: turbot_api_security_group
+      GroupDescription: API Service
+      VpcId: !Ref TurbotVpc
+      SecurityGroupEgress:
+        - Description: Loopback - required CloudFormation hack to avoid adding the default egress rule
+          CidrIp: 127.0.0.1/32
+          FromPort: 443
+          ToPort: 443
+          IpProtocol: tcp
+
+  LoadBalancerSgHttpsFromClients:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+      Description: HTTPS from Clients to LB
+      CidrIp: 0.0.0.0/0
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+
+  LoadBalancerSgHttpsToEcs:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+      Description: HTTPS from LB to ECS
+      DestinationSecurityGroupId: !GetAtt ApiServiceSecurityGroup.GroupId
+      IpProtocol: tcp
+      # We've observed that target groups often open ports in the 32k range
+      FromPort: 32768
+      ToPort: 65535
+
+  ApiServiceSgHttpsFromLoadBalancer:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt ApiServiceSecurityGroup.GroupId
+      Description: HTTPS from LB to API Containers
+      SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 32768
+      ToPort: 65535


### PR DESCRIPTION
- Useful for enterprise customers who are using custom VPCs.
- This CFN serves as a convenient starting point for what ports are required and the Guardrails security group naming conventions.