### PR TITLE
BigQuery DataSet Unapproved Access

### DIFF
--- a/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/README.md
+++ b/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/README.md
@@ -1,0 +1,109 @@
+---
+categories: [ "data protection", "security" ]
+primary_category: "data protection"
+type: "featured"
+---
+
+# Alert on GCP BigQuery Datasets with Unauthorized Access
+
+Alerting when a GCP BigQuery datasets has unauthorized access is crucial to protect sensitive and proprietary data from
+unauthorized access and potential breaches. By alerting on unauthorized access, organizations can maintain data privacy,
+comply with regulatory requirements, and safeguard against malicious activities.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following
+settings for BigQuery datasets:
+
+- Alert when unapproved access has been granted to a BigQuery DataSet
+- Specify a regex to identify unauthorized access.
+
+*
+
+*[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_bigquery_alert_dataset_unapproved_access)
+**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+    - [@turbot/gcp-bigquery](https://hub.guardrails.turbot.com/mods/gcp/mods/gcp-bigquery)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key)
+  in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please
+see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication)
+for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/bigquery/alert_dataset_unapproved_access
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Adjust Regex to Needs
+
+In the `GCP > BigQuery > DataSet > Apporved > Custom` policy setting, a regex is set to identify unapproved access. If an identity matches the regex then it is unapproved. 
+
+The default value is:
+
+```jinja2
+    {% set forbidden_regex = r/(?=.*dev-)(?=.*dtap)/g -%}
+```
+
+The regex should be adjusted to meet your needs. 
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace
+and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in
+that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!WARN]
+> By default, the policies are set to `Check` in the pack's policy settings. This policy setting should never be set to
+`Enforce`. If set to `Enforce` then Guardrails will attempt to destroy the DataSet that has unapproved access.
+
+There is no enforcement for this policy pack. 

--- a/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/main.tf
+++ b/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Alert on Unapproved BigQuery DataSet Access"
+  description = "Raises an alarm when an unapproved user/service account has access to a BigQuery Dataset"
+  akas        = ["alert_dataset_unapproved_access"]
+}

--- a/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/policies.tf
+++ b/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/policies.tf
@@ -1,0 +1,40 @@
+# GCP > BigQuery > DataSet > Approved
+resource "turbot_policy_setting" "gcp_bigquery_dataset_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-bigquery#/policy/types/datasetApproved"
+  value    = "Check: Approved"
+  note     = "Should never be set to Enforce, as Guardrails will attempt to destroy the dataset if unapproved access has been granted. "
+}
+
+# GCP > BigQuery > DataSet > Approved > Custom
+resource "turbot_policy_setting" "gcp_bigquery_dataset_approved_custom" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/gcp-bigquery#/policy/types/datasetApprovedCustom"
+  template_input = <<-EOT
+    {
+      dataset {
+        access: get(path: "access")
+      }
+    }
+  EOT
+
+  template       = <<-EOT
+    {% set forbidden_regex = r/(?=.*dev-)(?=.*dtap)/g -%}
+    {% set unapproved_found = false -%}
+    {% for grant in $.dataset.access -%}
+    {% if forbidden_regex.test(grant.userByEmail) or forbidden_regex.test(grant.groupByEmail)  -%}
+    - title: Unapproved Access
+      result: Not approved
+      message: Unapproved access was found for {% if grant.userByEmail %}{{ grant.userByEmail }}{% else %}{{ grant.groupByEmail }}{% endif %} with role of {{ grant.role }}.
+      {% set unapproved_found = true -%}
+    {% endif %}
+    {% endfor -%}
+    {% if not unapproved_found -%}
+    - title: Unapproved Access
+      result: Approved
+      message: No unapproved access was found.
+    {% endif -%}
+  EOT
+}
+
+

--- a/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/providers.tf
+++ b/policy_packs/gcp/bigquery/alert_dataset_unapproved_access/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
- Specify a regex.  Regex matches are unapproved.
- Closes https://github.com/turbot/guardrails-samples/issues/840