### PR TITLE
Add policy pack - Notification based on Budget

### DIFF
--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/README.md
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/README.md
@@ -1,0 +1,222 @@
+---
+categories: ["cost controls"]
+primary_category: "cost controls"
+---
+
+# Enable Turbot Notifications for AWS GovCloud Billing in Guardrails
+
+The Guardrails Event Handlers are responsible for conveying events from AWS CloudTrail back to Guardrails for processing. This is a requirement for Guardrails to process and respond in real-time.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you enable [Turbot Notifications](https://turbot.com/guardrails/docs/guides/notifications) for AWS Accounts in Guardrails.
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_guardrails_enable_turbot_notifications_govcloud_billing/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws](https://hub.guardrails.turbot.com/mods/aws/mods/aws)
+- [jq](https://jqlang.github.io/jq/)
+- [Steampipe](https://steampipe.io/downloads)
+- Steampipe Plugins:
+  - [CSV](https://hub.steampipe.io/plugins/turbot/csv)
+  - [Turbot Guardrails](https://hub.steampipe.io/plugins/turbot/guardrails)
+- AWS Standard accounts to GovCloud accounts mapping.
+  - Create a CSV file that maps Standard Cloud accounts to their corresponding GovCloud accounts using the format below. To help you get started, you can use Steampipe to generate this data. Run the following query against the **GovCloud Guardrails Workspace** connection:
+
+    ```bash
+    steampipe query "select 'TBD' as "standard_account_id", data ->> 'Id' as "govcloud_account_id", trunk_title as "govcloud_trunk_title", workspace as "govcloud_workspace", id as "govcloud_account_resource_id" from guardrails_resource where resource_type_uri  = 'tmod:@turbot/aws#/resource/types/account'" --output csv
+    ```
+
+  - The CSV format should look like this:
+
+    | standard_account_id | govcloud_account_id | govcloud_trunk_title            | govcloud_workspace                  | govcloud_account_resource_id |
+    |---------------------|---------------------|---------------------------------|-------------------------------------|------------------------------|
+    | TBD                 | 222222222222        | Turbot > Montlake > deadshot    | https://console.govcloud.turbot.com | 331269922199500              |
+    | TBD                 | 444444444444        | Turbot > waller > 444444444444  | https://console.govcloud.turbot.com | 330456246436869              |
+    | TBD                 | 666666666666        | Turbot > 666666666666           | https://sandbox.govcloud.turbot.com | 180698850662056              |
+    | TBD                 | 888888888888        | Turbot > devgov1 > 888888888888 | https://sandbox.govcloud.turbot.com | 325515057218706              |
+
+  - Enable the `AWS > Account > Budget > Budget` control in the Guardrails workspaces of the standard accounts.
+  - Run the following bash script for Standard Accounts Guardrails workspace.
+
+    ```bash
+    #!/bin/bash
+
+    echo "Running the Steampipe query..."
+    sp_query_output=$(steampipe query "SELECT 
+      jsonb_agg(
+        jsonb_build_object(
+          'standard_account_id', metadata -> 'aws' ->> 'accountId',
+          'govcloud_account_id', COALESCE(guest_accounts.govcloud_account_id::text, 'NA'),
+          'govcloud_trunk_title', COALESCE(guest_accounts.govcloud_trunk_title::text, 'NA'),
+          'govcloud_workspace', COALESCE(guest_accounts.govcloud_workspace::text, 'NA'),
+          'govcloud_account_resource_id', COALESCE(guest_accounts.govcloud_account_resource_id::text, 'NA'),
+          'budgetUpdatedSince', metadata ->> 'budgetUpdatedSince',
+          'currentMonthActualSpend', data ->> 'currentMonthActualSpend',
+          'currentMonthForecastSpend', data ->> 'currentMonthForecastSpend',
+          'lastUpdatedTime', data ->> 'lastUpdatedTime',
+          'lastAttemptTimestamp', metadata ->> 'lastAttemptTimestamp',
+          'standard_trunk_title', trunk_title
+        )
+      ) AS budget_details
+    FROM 
+      guardrails_resource AS guardrails
+    LEFT JOIN 
+      (SELECT standard_account_id, govcloud_account_id, govcloud_trunk_title, govcloud_workspace, govcloud_account_resource_id FROM csv.aws_standard_govcloud_account_mappings) AS guest_accounts
+    ON 
+      guardrails.metadata -> 'aws' ->> 'accountId' = guest_accounts.standard_account_id
+    WHERE 
+      guardrails.resource_type_uri = 'tmod:@turbot/aws#/resource/types/budget';" --output json | jq -r '.rows[0]' )
+
+    # putResource function
+    put_resource() {
+      echo "Updating the Turbot File resource..."
+      turbot graphql --query 'mutation PutResource($input: PutResourceInput!) {
+        putResource(input: $input) {
+          metadata
+          turbot {
+            akas
+            id
+          }
+        }
+      }' --variables "{
+        "input": {
+          "id": "aws_standard_govcloud_budget",
+          "metadata": {
+            "title": \"AWS Standard GovCloud Budget File\",
+            "description": \"AWS Standard GovCloud Budget File\"
+          },
+          "data": $sp_query_output
+        }
+      }"
+    }
+
+    # Check if the Turbot File resource exists
+    echo "Checking if the Turbot File exists..."
+    turbot graphql --query 'query checkForResource {
+      resource(id: "aws_standard_govcloud_budget") {
+        turbot {
+          id
+        }
+      }
+    }'
+
+    # Check the exit status of the previous command
+    if [[ $? -ne 0 ]]; then
+      echo "Turbot File resource does not exist. Creating the resource..."
+
+      # Create the resource
+      turbot graphql --query 'mutation turbotFileCreation {
+        createResource(
+          input: {
+            type: "tmod:@turbot/turbot#/resource/types/file",
+            akas: ["aws_standard_govcloud_budget"],
+            data: {},
+            parent: "tmod:@turbot/turbot#/",
+            metadata: {
+              title: "AWS Standard GovCloud Budget File",
+              description: "AWS Standard GovCloud Budget File"
+            }
+          }
+        ) {
+          turbot {
+            id
+          }
+        }
+      }'
+
+      # Call the update function after creating the resource
+      put_resource
+
+    else
+      echo "Resource exists."
+      # Call the update function if the resource exists
+      put_resource
+
+    fi
+    ```
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+> [!IMPORTANT]
+> Setting the policy in enabled mode will result in notifications of resources in the target workspace. However, it is easy to stop the notifications later, by setting the policy to `Disabled`.
+
+```hcl
+resource "turbot_policy_setting" "turbot_notifications" {
+  resource = "tmod:@turbot/turbot#/"
+  type     = "tmod:@turbot/turbot#/policy/types/notifications"
+  value    = "Enabled"
+  # value    = "Disabled"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/README.md
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/README.md
@@ -164,6 +164,8 @@ Please see [Turbot Guardrails Provider authentication](https://registry.terrafor
 > By default, installed policy packs are not attached to any resources.
 >
 > Policy packs must be attached to resources in order for their policy settings to take effect.
+>
+> The `Turbot > Notifications` policy and its associated sub-policies are applied at the Turbot level. As a result, only two policy settings will be visible when viewing the policy pack.
 
 Clone:
 

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/main.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  akas        = ["aws_guardrails_enable_turbot_notifications_govcloud_billing"]
+  title       = "Enable Turbot Notifications for Gov Cloud Billing in Guardrails"
+  description = "This policy pack ensures proactive budget management by sending real-time Turbot notifications when the set budget threshold is reached for a GovCloud account."
+}

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/policies.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/policies.tf
@@ -1,5 +1,3 @@
-
-
 # AWS > Account > Budget > Enabled
 resource "turbot_policy_setting" "aws_account_budget_enabled" {
   resource = turbot_policy_pack.main.id
@@ -11,7 +9,7 @@ resource "turbot_policy_setting" "aws_account_budget_enabled" {
 resource "turbot_policy_setting" "aws_account_budget_limit" {
   resource = turbot_policy_pack.main.id
   type     = "tmod:@turbot/aws#/policy/types/accountBudgetLimit"
-  value    = 500
+  value    = var.aws_account_budget_target
 }
 
 # Turbot > Notifications

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/policies.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/policies.tf
@@ -1,0 +1,149 @@
+
+
+# AWS > Account > Budget > Enabled
+resource "turbot_policy_setting" "aws_account_budget_enabled" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws#/policy/types/accountBudgetEnabled"
+  value    = "Check: Budget > State is On Target or below"
+}
+
+# AWS > Account > Budget > Target
+resource "turbot_policy_setting" "aws_account_budget_limit" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws#/policy/types/accountBudgetLimit"
+  value    = 500
+}
+
+# Turbot > Notifications
+resource "turbot_policy_setting" "turbot_notifications" {
+  resource = "tmod:@turbot/turbot#/"
+  type     = "tmod:@turbot/turbot#/policy/types/notifications"
+  value    = "Enabled"
+  # value    = "Disabled"
+}
+
+# Turbot > Notifications > Rule-Based Routing
+resource "turbot_policy_setting" "turbot_notifications_rule_based_routing" {
+  resource = "tmod:@turbot/turbot#/"
+  type     = "tmod:@turbot/turbot#/policy/types/notificationsRuleBasedRouting"
+  value    = <<-EOT
+    [
+      {
+        "rules": "NOTIFY $.oldControl.state:ok $.control.state:alarm $.controlType.uri:'tmod:@turbot/aws#/control/types/budget'",
+        "emails": ${jsonencode(split(",", var.email_ids))}
+      }
+    ]
+    EOT
+}
+
+# Turbot > Notifications > Email > Control Template > Body
+resource "turbot_policy_setting" "turbot_notifications_email_control_template_body" {
+  resource = "tmod:@turbot/turbot#/"
+  type     = "tmod:@turbot/turbot#/policy/types/notificationsEmailControlTemplateBody"
+  value    = <<-EOT
+    {% input %}
+    query controlGet($id: ID!, $resourceId: ID!, $filter: [String!]) {
+      workspaceUrl: policyValue(uri: "tmod:@turbot/turbot#/policy/types/workspaceUrl", resourceId:$resourceId){
+          value
+        }
+      aws_standard_govcloud_budget: resource(id:"aws_standard_govcloud_budget"){
+          data 
+        }
+      resource {
+        turbot {
+          custom
+        }
+      }
+      oldControl: control(id: $id) {
+        actor {
+          identity {
+            picture
+            turbot {
+              title
+              id
+            }
+          }
+        }
+        state
+        reason
+        details
+        type {
+          trunk {
+            title
+          }
+        }
+        turbot {
+          createTimestamp
+          updateTimestamp
+          id
+        }
+        resource {
+          turbot {
+            id
+          }
+          trunk {
+            title
+          }
+          type {
+            title
+          }
+        }
+      }
+      quickActions: controlTypes(filter: $filter) {
+        items {
+          actionTypes{
+            items{
+              title
+              icon
+              description
+              uri
+              confirmationType
+              defaultActionPermissionLevels
+              turbot {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+
+    {% endinput %}
+
+    <!DOCTYPE html>
+    <html>
+      <head>
+          <meta charset="UTF-8">
+          <title>Email Content</title>
+      </head>
+      <body>
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0;">RESOURCE</p>
+          <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">
+            <a style="color: #0000FF; text-decoration: none;" href="{%- set match_found = false -%}{%- for budget in $.aws_standard_govcloud_budget.data.budget_details -%}{%- if budget.standard_account_id == $.resource.turbot.custom.aws.accountId -%}{{ budget.govcloud_workspace }}/apollo/resources/{{ budget.govcloud_account_resource_id }}{%- set match_found = true -%}{%- endif -%}{%- endfor -%}{%- if not match_found -%}{%- endif %}">{%- set match_found = false -%}{%- for budget in $.aws_standard_govcloud_budget.data.budget_details -%}{%- if budget.standard_account_id == $.resource.turbot.custom.aws.accountId -%}{{ budget.govcloud_trunk_title | replace('>', '&gt;') }}{%- set match_found = true -%}{%- endif -%}{%- endfor -%}{%- if not match_found -%}""{%- endif %}</a>
+          </p>
+
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-top: 20px;">CONTROL</p>
+          <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">
+            <a style="color: #0000FF; text-decoration: none;" href="{{ domain }}/controls/{{$.oldControl.turbot.id }}">{{ $.oldControl.type.trunk.title | replace('>', '&gt;')}}</a>
+          </p>
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-top: 20px;">STATUS</p>
+          <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">{% if $.oldControl.state == 'ok' %}OK{% elif $.oldControl.state == 'tbd'%}TBD{% else %}{{ $.oldControl.state | capitalize }}{% endif %}  → <span style="font-weight: bold; {% if newControl.state == 'alarm' or newControl.state == 'error' %}color: #CC0000;{% elif newControl.state == 'ok' %}color: #36a64f;{% else %}color: #d3d3d3;{% endif %}">{% if newControl.state == 'ok' %}OK{% elif newControl.state == 'tbd'%}TBD{% else %}{{ newControl.state | capitalize }}{% endif %}</span></p>
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-top: 20px;">REASON</p>
+          <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">{{ newControl.reason }}</p>
+          {%- if $.quickActions.items and $.quickActions.items[0].actionTypes and $.quickActions.items[0].actionTypes.items.length > 0 %}
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-top: 20px;">QUICK ACTIONS</p>
+          <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">
+            {% for item in $.quickActions.items[0].actionTypes.items -%}
+            &rarr; <a style="color: #0000FF; text-decoration: none;" href="{{ domain }}/resources/{{ $.oldControl.resource.turbot.id }}?executeActionType={{ item.uri | replace('#', '%23')}}">{{ item.title }}</a><br>
+            {% endfor -%}
+          </p>
+          {% endif -%}
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-top: 20px;">TIMESTAMP</p>
+          <p  style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">{{ newControl.turbot.updateTimestamp }} UTC <a style="color: #0000FF; text-decoration: none;" href="{{ domain }}/processes/{{ process.id }}/logs?filter=logLevel%3A>%3Dinfo">[Log]</a></p>
+          <div style="font-size: 11px; color: #848884; margin-top: 20px;">
+            You have been subscribed to these email alerts by the system administrator of <a style="color: #0000FF; text-decoration: none;" href="{{ domain }}">{{ domain }}</a>. Please contact them directly for changes.
+          </div>
+      </body>
+    </html>
+    EOT
+}

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/policies.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/policies.tf
@@ -34,6 +34,75 @@ resource "turbot_policy_setting" "turbot_notifications_rule_based_routing" {
     EOT
 }
 
+# Turbot > Notifications > Email > Control Template > Subject
+resource "turbot_policy_setting" "turbot_notifications_email_control_template_subject" {
+  resource = "tmod:@turbot/turbot#/"
+  type     = "tmod:@turbot/turbot#/policy/types/notificationsEmailControlTemplateSubject"
+  value    = <<-EOT
+    {% input %}
+    query controlGet($id: ID!, $resourceId: ID!) {
+      workspaceUrl: policyValue(uri: "tmod:@turbot/turbot#/policy/types/workspaceUrl", resourceId:$resourceId){
+          value
+        }
+      aws_standard_govcloud_budget: resource(id:"aws_standard_govcloud_budget"){
+          data 
+        }
+      resource {
+        turbot {
+          custom
+        }
+      }
+      oldControl: control(id: $id) {
+        state
+        type {
+          title
+          trunk {
+            title
+          }
+        }
+        reason
+        resource {
+          type {
+            title
+          }
+          metadata
+          trunk {
+            title
+          }
+        }
+        turbot {
+          updateTimestamp
+          createTimestamp
+        }
+      }
+    }
+
+    {% endinput %}
+
+    {%- set match_found = false -%}
+    {%- for budget in $.aws_standard_govcloud_budget.data.budget_details -%}
+    {%- if budget.standard_account_id == $.resource.turbot.custom.aws.accountId -%}
+    {%- if not budget.govcloud_workspace or budget.govcloud_workspace != "NA" -%}
+    {%- set govcloudworkspace = budget.govcloud_workspace -%}
+    {% set workspace = govcloudworkspace.split('/')[2].split('.')[0] %}
+    {%- set match_found = true -%}
+    "[{{workspace}}] {% if $.oldControl.state == 'tbd' or $.oldControl.state == 'ok' %}{{ $.oldControl.state | upper }}{% else %}{{ $.oldControl.state | capitalize }}{% endif %} → {% if newControl.state == 'tbd' or newControl.state == 'ok' %}{{ newControl.state | upper }}{% else %}{{ newControl.state | capitalize }}{% endif %}: {{ $.oldControl.type.trunk.title }} for {{ budget.govcloud_trunk_title }} at {{ newControl.turbot.updateTimestamp }} UTC"
+    {%- endif -%}
+    {%- endif -%}{%- endfor -%}
+
+    {%- if not match_found -%}
+    {%- if domain %}
+    {% set workspace = domain.split('/')[2].split('.')[0] %}
+    "[{{workspace}}] {% if $.oldControl.state == 'tbd' or $.oldControl.state == 'ok' %}{{ $.oldControl.state | upper }}{% else %}{{ $.oldControl.state | capitalize }}{% endif %} → {% if newControl.state == 'tbd' or newControl.state == 'ok' %}{{ newControl.state | upper }}{% else %}{{ newControl.state | capitalize }}{% endif %}: {{ $.oldControl.type.trunk.title }} for {{ $.oldControl.resource.trunk.title }} at {{ newControl.turbot.updateTimestamp }} UTC"
+    {%- else %}
+    {% set workspace = "" %}
+    "{% if $.oldControl.state == 'tbd' or $.oldControl.state == 'ok' %}{{ $.oldControl.state | upper }}{% else %}{{ $.oldControl.state | capitalize }}{% endif %} → {% if newControl.state == 'tbd' or newControl.state == 'ok' %}{{ newControl.state | upper }}{% else %}{{ newControl.state | capitalize }}{% endif %}: {{ $.oldControl.type.trunk.title }} for {{ $.oldControl.resource.trunk.title }} at {{ newControl.turbot.updateTimestamp }} UTC"
+    {%- endif %}
+    {%- endif %}
+
+    EOT
+}
+
 # Turbot > Notifications > Email > Control Template > Body
 resource "turbot_policy_setting" "turbot_notifications_email_control_template_body" {
   resource = "tmod:@turbot/turbot#/"
@@ -115,7 +184,12 @@ resource "turbot_policy_setting" "turbot_notifications_email_control_template_bo
           <title>Email Content</title>
       </head>
       <body>
-          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0;">RESOURCE</p>
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0;">STANDARD RESOURCE</p>
+          <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">
+            <a style="color: #0000FF; text-decoration: none;" href="{{ domain }}/resources/{{$.oldControl.resource.turbot.id }}">{{ $.oldControl.resource.trunk.title | replace('>', '&gt;')}}</a>
+          </p>
+
+          <p style="color: #999999; font-size: 10px; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0;">GOVCLOUD RESOURCE</p>
           <p style="font-size: small; font-family: Arial, Helvetica, sans-serif; margin-top: 0;">
             <a style="color: #0000FF; text-decoration: none;" href="{%- set match_found = false -%}{%- for budget in $.aws_standard_govcloud_budget.data.budget_details -%}{%- if budget.standard_account_id == $.resource.turbot.custom.aws.accountId -%}{{ budget.govcloud_workspace }}/apollo/resources/{{ budget.govcloud_account_resource_id }}{%- set match_found = true -%}{%- endif -%}{%- endfor -%}{%- if not match_found -%}{%- endif %}">{%- set match_found = false -%}{%- for budget in $.aws_standard_govcloud_budget.data.budget_details -%}{%- if budget.standard_account_id == $.resource.turbot.custom.aws.accountId -%}{{ budget.govcloud_trunk_title | replace('>', '&gt;') }}{%- set match_found = true -%}{%- endif -%}{%- endfor -%}{%- if not match_found -%}""{%- endif %}</a>
           </p>

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/providers.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/variables.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/variables.tf
@@ -2,3 +2,8 @@ variable "email_ids" {
   description = "Comma-seperated email IDs to send the Turbot Notifications. Example: user1@example.com,user2@example.com,user3@example.com"
   type        = string
 }
+
+variable "aws_account_budget_target" {
+  description = "The budget target for this AWS Account, in US Dollars. The Budget > state is calculated by comparing this target to the Current Spend and Forecast Spend."
+  type        = number
+}

--- a/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/variables.tf
+++ b/policy_packs/aws/guardrails/enable_turbot_notifications_govcloud_billing/variables.tf
@@ -1,0 +1,4 @@
+variable "email_ids" {
+  description = "Comma-seperated email IDs to send the Turbot Notifications. Example: user1@example.com,user2@example.com,user3@example.com"
+  type        = string
+}


### PR DESCRIPTION
* When the Standard account has its mapping for GovCloud account:
  * The subject line includes the GovCloud workspace details and the Resource trunk title of govcloud resource

>  <img width="1041" alt="image" src="https://github.com/user-attachments/assets/1ce0037c-5340-4082-874a-378a4b22d3ab">

* When the Standard account does not have a mapping for GovCloud account
  * The subject line includes the Standard workspace details and the Resource trunk title of standard resource

>  <img width="1041" alt="image" src="https://github.com/user-attachments/assets/39a66789-5b7e-4f36-9ed5-f5a9c9637469">
