### PR TITLE
Add AWS policy pack - Tagging Helpers for Cost_Center. Closes #865

### DIFF
--- a/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/README.md
+++ b/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/README.md
@@ -1,0 +1,101 @@
+---
+categories: ["storage", "tagging"]
+primary_category: "tagging"
+---
+
+# Enforce Cost Center Tag Transform for AWS S3 Buckets
+
+Enforcing the standardization of the `Cost_Center` tag is essential for maintaining consistency across AWS S3 Buckets. This policy ensures that variations in the tag format are automatically corrected, improving the organization of resources and supporting accurate cost allocation, budgeting, and compliance with financial governance policies.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
+
+- Enforce `Cost_Center` tag key
+
+- **[Review Policy settings →](https://hub.guardrails.turbot.com/policy-packs/aws_s3_enforce_cost_center_tag_transform_for_buckets/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/aws-s3](https://hub.guardrails.turbot.com/mods/aws/mods/aws-s3)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "aws_s3_bucket_tags" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-s3#/policy/types/bucketTags"
+  # value    = "Check: Tags are correct"
+  value    = "Enforce: Set tags"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/main.tf
+++ b/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Cost Center Tag Transform for AWS S3 Buckets"
+  description = "Enforcing a consistent format for the `Cost_Center` tag key ensures that all tags are uniform, helping to keep resources organized and making tracking and management easier."
+  akas        = ["aws_s3_enforce_cost_center_tag_transform_for_buckets"]
+}

--- a/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/policies.tf
+++ b/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/policies.tf
@@ -1,0 +1,51 @@
+locals {
+  yaml_string = <<-EOT
+    Cost_Center:
+      incorrectKeys:
+        - /.*cost.*cent.*/gi
+      replacementValue: undefined
+    EOT
+}
+
+# Turbot > File
+resource "turbot_file" "aws_tag_transform_rules" {
+  parent  = "tmod:@turbot/turbot#/"
+  title   = "AWS Tag Transform Rules"
+  akas    = ["aws_tag_transform_rules"]
+  content = jsonencode(yamldecode(local.yaml_string))
+}
+
+# AWS > S3 > Bucket > Tags
+resource "turbot_policy_setting" "aws_s3_bucket_tags" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/aws-s3#/policy/types/bucketTags"
+  value    = "Check: Tags are correct"
+  # value    = "Enforce: Set tags"
+}
+
+# AWS > S3 > Bucket > Tags > Template
+resource "turbot_policy_setting" "aws_s3_bucket_tags_template" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/aws-s3#/policy/types/bucketTagsTemplate"
+  template_input = <<-EOT
+    {
+      rules: resource(id:"aws_tag_transform_rules") {
+        data
+      }
+      resource {
+        turbot {
+          tags
+        }
+      }
+    }
+    EOT
+  template       = <<-EOT
+    {%- set tags_map = $.resource.turbot.tags -%}
+    {%- set rules = $.rules.data -%}
+
+    {% for key,value in transformMap(tags_map, rules) -%}
+    - "{{key}}": "{{value}}"
+    {% endfor -%}
+
+    EOT
+}

--- a/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/providers.tf
+++ b/policy_packs/aws/s3/enforce_cost_center_tag_transform_for_buckets/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
Current Tags on the S3 Bucket: `cost-centre`:`A3579`

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/4aa016e2-43a5-4ba7-8e1d-1f830ddaa9f5">

Once the Policy Pack is attached, Turbot Identifies

```
Current tags | Alarm | cost-centre: A3579
Tags to create | Alarm | Cost_Center: A3579
Tags to update | OK |  
Tags to delete | Alarm | cost-centre: A3579
```

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/1cfdc134-fe37-4a5f-89d5-d99e2fdc6341">

Turbot has Enforced the `Cost_Center` Tag Transform 
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/e3101bc0-6a08-44ed-8110-6dc36ba0de18">

Tags on S3 Bucket after enforcement:
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/d32bef96-9b03-4722-a2c3-a14eeabf3bef">
