### PR TITLE
Add Azure policy pack - Tagging Helpers for Cost_Center. Closes #865

### DIFF
--- a/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/README.md
+++ b/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/README.md
@@ -1,0 +1,101 @@
+---
+categories: ["storage", "tagging"]
+primary_category: "tagging"
+---
+
+# Enforce Cost Center Tag Transform for Azure Storage Accounts
+
+Enforcing the standardization of the `Cost_Center` tag is essential for maintaining consistency across Azure Storage Accounts. This policy ensures that variations in the tag format are automatically corrected, improving the organization of resources and supporting accurate cost allocation, budgeting, and compliance with financial governance policies.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for Storage Accounts:
+
+- Enforce `Cost_Center` tag key
+
+- **[Review Policy settings →](https://hub.guardrails.turbot.com/policy-packs/azure_storage_enforce_cost_center_tag_transform_for_storage_accounts/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/azure-storage](https://hub.guardrails.turbot.com/mods/azure/mods/azure-storage)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "azure_storage_storage_account_tags" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-storage#/policy/types/storageAccountTags"
+  # value    = "Check: Tags are correct"
+  value    = "Enforce: Set tags"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/main.tf
+++ b/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Cost Center Tag Transform for Azure Storage Accounts"
+  description = "Enforcing a consistent format for the `Cost_Center` tag key ensures that all tags are uniform, helping to keep resources organized and making tracking and management easier."
+  akas        = ["azure_storage_enforce_cost_center_tag_transform_for_storage_accounts"]
+}

--- a/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/policies.tf
+++ b/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/policies.tf
@@ -1,0 +1,50 @@
+locals {
+  yaml_string = <<-EOT
+    Cost_Center:
+      incorrectKeys:
+        - /.*cost.*cent.*/gi
+      replacementValue: undefined
+    EOT
+}
+
+# Turbot > File
+resource "turbot_file" "azure_tag_transform_rules" {
+  parent  = "tmod:@turbot/turbot#/"
+  title   = "Azure Tag Transform Rules"
+  akas    = ["azure_tag_transform_rules"]
+  content = jsonencode(yamldecode(local.yaml_string))
+}
+
+# Azure > Storage > Storage Account > Tags
+resource "turbot_policy_setting" "azure_storage_storage_account_tags" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/azure-storage#/policy/types/storageAccountTags"
+  value    = "Enforce: Set tags"
+}
+
+# Azure > Storage > Storage Account > Tags > Template
+resource "turbot_policy_setting" "azure_storage_account_tags_template" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/azure-storage#/policy/types/storageAccountTagsTemplate"
+  template_input = <<-EOT
+    {
+      rules: resource(id:"tag_transform_rules") {
+        data
+      }
+      resource {
+        turbot {
+          tags
+        }
+      }
+    }
+    EOT
+  template       = <<-EOT
+    {%- set tags_map = $.resource.turbot.tags -%}
+    {%- set rules = $.rules.data -%}
+
+    {% for key,value in transformMap(tags_map, rules) -%}
+    - "{{key}}": "{{value}}"
+    {% endfor -%}
+
+    EOT
+}

--- a/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/policies.tf
+++ b/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/policies.tf
@@ -19,7 +19,8 @@ resource "turbot_file" "azure_tag_transform_rules" {
 resource "turbot_policy_setting" "azure_storage_storage_account_tags" {
   resource = turbot_policy_pack.main.id
   type     = "tmod:@turbot/azure-storage#/policy/types/storageAccountTags"
-  value    = "Enforce: Set tags"
+  value    = "Check: Tags are correct"
+  # value    = "Enforce: Set tags"
 }
 
 # Azure > Storage > Storage Account > Tags > Template

--- a/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/policies.tf
+++ b/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/policies.tf
@@ -29,7 +29,7 @@ resource "turbot_policy_setting" "azure_storage_account_tags_template" {
   type           = "tmod:@turbot/azure-storage#/policy/types/storageAccountTagsTemplate"
   template_input = <<-EOT
     {
-      rules: resource(id:"tag_transform_rules") {
+      rules: resource(id:"azure_tag_transform_rules") {
         data
       }
       resource {

--- a/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/providers.tf
+++ b/policy_packs/azure/storage/enforce_cost_center_tag_transform_for_storage_accounts/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
Tags on Storage Account: `cost-Centre`: `Z4192`

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/990bd6dc-13f5-42f7-b31f-c2cc7489bd20">

Once the Policy Pack is attached, Turbot identifies

```
tagsToCreate:
  Cost_Center: Z4192
tagsToUpdate: {}
tagsToDelete:
  cost-Centre: Z4192
updates: true
```

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/2ea37962-ab51-43f5-b3b5-fbd3e8932bba">

Turbot has Enforced the Cost_Center Tag Transform

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/567bc8d8-c63a-4c30-b146-5413f56867c9">

Tags on Storage Account after enforcement:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/7d7df4db-0771-475c-9943-79a5a2fe46b1">
