### PR TITLE
Add GCP policy pack - Tagging Helpers for Cost_Center. Closes #865

### DIFF
--- a/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/README.md
+++ b/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/README.md
@@ -1,0 +1,101 @@
+---
+categories: ["storage", "tagging"]
+primary_category: "tagging"
+---
+
+# Enforce Cost Center Label Transform for AWS S3 Buckets
+
+Enforcing the standardization of the `Cost_Center` label is essential for maintaining consistency across GCP Storage Buckets. This policy ensures that variations in the label format are automatically corrected, improving the organization of resources and supporting accurate cost allocation, budgeting, and compliance with financial governance policies.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for S3 buckets:
+
+- Enforce `cost_center` label key
+
+- **[Review Policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_storage_enforce_cost_center_label_transform_for_buckets/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/gcp-storage](https://hub.guardrails.turbot.com/mods/gcp/mods/gcp-storage)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "gcp_storage_bucket_labels" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-storage#/policy/types/bucketLabels"
+  # value    = "Check: Labels are correct"
+  value    = "Enforce: Set labels"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/main.tf
+++ b/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce Cost Center Label Transform for GCP Storage Buckets"
+  description = "Enforcing a consistent format for the `Cost_Center` label key ensures that all labels are uniform, helping to keep resources organized and making tracking and management easier."
+  akas        = ["gcp_storage_enforce_cost_center_label_transform_for_buckets"]
+}

--- a/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/policies.tf
+++ b/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/policies.tf
@@ -1,0 +1,53 @@
+locals {
+  yaml_string = <<-EOT
+    cost_center:
+      incorrectKeys:
+        - /.*cost.*cent.*/gi
+      replacementValue: undefined
+    EOT
+}
+
+# Turbot > File
+resource "turbot_file" "gcp_label_transform_rules" {
+  parent  = "tmod:@turbot/turbot#/"
+  title   = "GCP Label Transform Rules"
+  akas    = ["gcp_label_transform_rules"]
+  content = jsonencode(yamldecode(local.yaml_string))
+}
+
+# GCP > Storage > Bucket > Labels
+resource "turbot_policy_setting" "gcp_storage_bucket_labels" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-storage#/policy/types/bucketLabels"
+  value    = "Check: Labels are correct"
+  # value    = "Enforce: Set labels"
+}
+
+# GCP > Storage > Bucket > Labels > Template
+resource "turbot_policy_setting" "gcp_bucket_labels_template" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/gcp-storage#/policy/types/bucketLabelsTemplate"
+  template_input = <<-EOT
+    {
+      rules: resource(id:"gcp_label_transform_rules") {
+        data
+      }
+      resource {
+        turbot {
+          tags
+        }
+      }
+    }
+    EOT
+  template       = <<-EOT
+    {%- set tags_map = $.resource.turbot.tags -%}
+    {%- set rules = $.rules.data -%}
+
+    {% for key,value in transformMap(tags_map, rules) -%}
+    - "{{key}}": "{{value}}"
+    {% endfor -%}
+
+    EOT
+}
+
+

--- a/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/providers.tf
+++ b/policy_packs/gcp/storage/enforce_cost_center_label_transform_for_buckets/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
Current Labels on the Storage Bucket: `costcentre`:`g3770`

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/b0ac4a96-fce2-4e5f-9aa8-48088178c6b7">

Once the Policy Pack is attached, Turbot Identifies

```
tagsToCreate:
  cost_center: g3770
tagsToUpdate: {}
tagsToDelete:
  costcentre: g3770
updates: true
```

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/35794d31-4874-41b6-80f0-05ac6e4e72c9">

Turbot has Enforced the `cost_center` label Transform

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/8f9886c4-d94f-411e-9621-432740b6a843">

Labels on Storage Bucket after enforcement:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/88ccbdd6-9b02-46ab-a657-97a4170f9827">
