### PR TITLE
Add policy pack - Validate GCP > Project User for any unapproved role association. Closes #889

### DIFF
--- a/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/README.md
+++ b/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/README.md
@@ -1,0 +1,102 @@
+---
+categories: ["access management", "security"]
+primary_category: "access management"
+type: "featured"
+---
+
+# Enforce GCP IAM Project Users Do Not Have Restricted Roles Assigned
+
+Enforcing that GCP IAM Project Users do not have restricted roles assigned is essential for maintaining the principle of least privilege. This minimizes the risk of unauthorized access and potential misuse of administrative capabilities, enhancing security by ensuring that service accounts only have the permissions necessary to perform their specific tasks.
+
+This [policy pack](https://turbot.com/guardrails/docs/concepts/policy-packs) can help you configure the following settings for IAM Project Users:
+
+- Delete Project Users if new that have the Restricted Roles Assigned
+
+**[Review policy settings →](https://hub.guardrails.turbot.com/policy-packs/gcp_iam_enforce_project_users_do_not_have_restricted_roles_assigned/settings)**
+
+## Getting Started
+
+### Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- Guardrails mods:
+  - [@turbot/gcp-iam](https://hub.guardrails.turbot.com/mods/gcp/mods/gcp-iam)
+
+### Credentials
+
+To create a policy pack through Terraform:
+
+- Ensure you have `Turbot/Admin` permissions (or higher) in Guardrails
+- [Create access keys](https://turbot.com/guardrails/docs/guides/iam/access-keys#generate-a-new-guardrails-api-access-key) in Guardrails
+
+And then set your credentials:
+
+```sh
+export TURBOT_WORKSPACE=myworkspace.acme.com
+export TURBOT_ACCESS_KEY=acce6ac5-access-key-here
+export TURBOT_SECRET_KEY=a8af61ec-secret-key-here
+```
+
+Please see [Turbot Guardrails Provider authentication](https://registry.terraform.io/providers/turbot/turbot/latest/docs#authentication) for additional authentication methods.
+
+## Usage
+
+### Install Policy Pack
+
+> [!NOTE]
+> By default, installed policy packs are not attached to any resources.
+>
+> Policy packs must be attached to resources in order for their policy settings to take effect.
+
+Clone:
+
+```sh
+git clone https://github.com/turbot/guardrails-samples.git
+cd guardrails-samples/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned
+```
+
+Run the Terraform to create the policy pack in your workspace:
+
+```sh
+terraform init
+terraform plan
+```
+
+Then apply the changes:
+
+```sh
+terraform apply
+```
+
+### Apply Policy Pack
+
+Log into your Guardrails workspace and [attach the policy pack to a resource](https://turbot.com/guardrails/docs/guides/policy-packs#attach-a-policy-pack-to-a-resource).
+
+If this policy pack is attached to a Guardrails folder, its policies will be applied to all accounts and resources in that folder. The policy pack can also be attached to multiple resources.
+
+For more information, please see [Policy Packs](https://turbot.com/guardrails/docs/concepts/policy-packs).
+
+### Enable Enforcement
+
+> [!TIP]
+> You can also update the policy settings in this policy pack directly in the Guardrails console.
+>
+> Please note your Terraform state file will then become out of sync and the policy settings should then only be managed in the console.
+
+By default, the policies are set to `Check` in the pack's policy settings. To enable automated enforcements, you can switch these policies settings by adding a comment to the `Check` setting and removing the comment from one of the listed enforcement options:
+
+```hcl
+resource "turbot_policy_setting" "gcp_iam_project_user_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-iam#/policy/types/projectUserApproved"
+  # value    = "Check: Approved"
+  value    = "Enforce: Delete unapproved if new"
+}
+```
+
+Then re-apply the changes:
+
+```sh
+terraform plan
+terraform apply
+```

--- a/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/main.tf
+++ b/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/main.tf
@@ -1,0 +1,5 @@
+resource "turbot_policy_pack" "main" {
+  title       = "Enforce GCP IAM Project Users do not have Restricted Roles assigned"
+  description = "Ensures that project users do not have Restricted roles assigned. This reduces the risk of over-privileged access and enhances security by enforcing least privilege principles for project users."
+  akas        = ["gcp_iam_enforce_project_users_do_not_have_restricted_roles_assigned"]
+}

--- a/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/policies.tf
+++ b/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/policies.tf
@@ -1,0 +1,50 @@
+# GCP > IAM > Project User > Approved
+resource "turbot_policy_setting" "gcp_iam_project_user_approved" {
+  resource = turbot_policy_pack.main.id
+  type     = "tmod:@turbot/gcp-iam#/policy/types/projectUserApproved"
+  value    = "Check: Approved"
+  # value    = "Enforce: Delete unapproved if new"
+}
+
+# GCP > IAM > Project User > Approved > Custom
+resource "turbot_policy_setting" "gcp_iam_project_user_approved_custom" {
+  resource       = turbot_policy_pack.main.id
+  type           = "tmod:@turbot/gcp-iam#/policy/types/projectUserApprovedCustom"
+  template_input = <<-EOT
+    {
+      resource {
+        data
+      }
+    }
+    EOT
+  template       = <<-EOT
+    {%- set restrictedRoles = [
+        "roles/editor", 
+        "roles/owner", 
+        "roles/viewer", 
+        "roles/resourcemanager.tagUser", 
+        "roles/resourcemanager.tagAdmin",  
+        "roles/iam.serviceAccountTokenCreator", 
+        "roles/iam.serviceAccountUser"
+    ] -%}
+
+    {%- set email = $.resource.data.userId -%}
+    {%- set assignedRestrictedRoles = [] -%}
+
+    {%- for role in $.resource.data.roles -%}
+      {%- if role in restrictedRoles -%}
+        {%- set assignedRestrictedRoles = assignedRestrictedRoles.concat([role]) -%}
+      {%- endif -%}
+    {%- endfor -%}
+
+    {%- if assignedRestrictedRoles | length > 0 -%}
+    - "title": "Role Assignments"
+      "result": "Not approved"
+      "message": "The user {{ email }} has restricted role(s): {{ assignedRestrictedRoles | join(", ") }} assigned."
+    {%- else -%}
+    - "title": "Role Assignments"
+      "result": "Approved"
+      "message": "The user {{ email }} does not have any restricted roles assigned."
+    {%- endif -%}
+    EOT
+}

--- a/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/providers.tf
+++ b/policy_packs/gcp/iam/enforce_project_users_do_not_have_restricted_roles_assigned/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    turbot = {
+      source  = "turbot/turbot"
+      version = ">= 1.11.0"
+    }
+  }
+}
+
+provider "turbot" {
+}


### PR DESCRIPTION
**Policy Pack**
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/51964578-cef9-474f-bc13-e42a85c0c76c">

* When Project user is assigned with restricted roles
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/3ab50802-b3c3-498d-a4ec-19e80e2443e6">

* When Project user does not have any restricted roles
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/7df06254-923f-41fa-854d-c5f4072b4d71">
