### PR TITLE
Add account-scoped filtering to snapshot AMI association policy

### DIFF
--- a/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/policies.tf
+++ b/policy_packs/aws/ec2/enforce_snapshots_active_check_if_ami_attached/policies.tf
@@ -1,8 +1,8 @@
 # AWS > EC2 > Snapshot > Active (Multi-query Calculated Policy)
 #
 # Logic:
-# - The first query gets the SnapshotId of the current snapshot resource.
-# - The second query searches for any AMI (Amazon Machine Image) resources
+# - The first query gets the SnapshotId of the current snapshot resource and the account ID.
+# - The second query searches for any AMI (Amazon Machine Image) resources in the current account
 #   where any BlockDeviceMappings[].Ebs.SnapshotId matches this snapshot's ID.
 #   (This is found in the AMI's data block, e.g.:
 #     BlockDeviceMappings:
@@ -10,6 +10,14 @@
 #         Ebs:
 #           SnapshotId: snap-03f6d591f26abd4f4
 #           ...)
+# - We only search for AMIs in the current AWS account when trying to associate snapshots with AMIs.
+#   This is safe because:
+#   - Snapshots created automatically during AMI creation always reside in the same account as the AMI.
+#   - If a snapshot was shared from another account and used to create an AMI here,
+#     it would first have to be copied, resulting in a new snapshot owned by this account.
+#     The AMI would then reference that new local snapshot.
+#   - Therefore, any snapshot in the current account that is part of an AMI
+#     will have that AMI registered in the same account.
 # - If any AMIs reference this snapshot, the policy returns 'Check: Active'
 #   (meaning the snapshot is still in use and should not be deleted).
 # - If no AMIs reference this snapshot, the policy returns
@@ -25,6 +33,11 @@ resource "turbot_policy_setting" "aws_ec2_snapshot_active" {
         resource {
           snapshot_id: get(path: "SnapshotId")
         }
+        account {
+          turbot {
+            id
+          }
+        }
       }
     - |
       {
@@ -32,7 +45,7 @@ resource "turbot_policy_setting" "aws_ec2_snapshot_active" {
           data
           snapshot_id: get(path: "SnapshotId")
         }
-        images: resources(filter: "resourceType:'tmod:@turbot/aws-ec2#/resource/types/ami' $.BlockDeviceMappings.*.Ebs.SnapshotId:{{$.resource.snapshot_id}} limit:5000") {
+        images: resources(filter: "resourceId:{{ $.account.turbot.id }} resourceTypeId:'tmod:@turbot/aws-ec2#/resource/types/ami' $.BlockDeviceMappings.*.Ebs.SnapshotId:{{$.resource.snapshot_id}} limit:5000") {
           metadata {
             stats {
               total


### PR DESCRIPTION
- Scope AMI search to current account for better performance and accuracy
- Add documentation explaining why account-scoping is safe
- Prevents false positives from cross-account AMI references